### PR TITLE
Add Stremio streaming and access controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Configure AIOStreams with your provider, then paste the manifest URL into Fetche
 
 Fetcherr also supports EasyNews streams when they are returned by AIOStreams as direct playable URLs. When AIOStreams returns mixed EasyNews, TorBox, and Real-Debrid candidates, Fetcherr tries EasyNews first, then falls back to TorBox or Real-Debrid.
 
+## Search Results
+
+Fetcherr exposes Jellyfin-compatible search results from both the synced library and configured Stremio add-ons. This lets clients find playable movies and shows returned by providers such as AIOStreams, then open them through the same Fetcherr playback resolver used by library items.
+
+For shows, Fetcherr hydrates search results into seasons and aired episodes so clients can drill into a result before playback. Future or unaired episodes are hidden from search drill-downs using the same visibility rules as the local library.
+
+## Media Source Selection
+
+Fetcherr can optionally expose multiple cached stream candidates as Jellyfin media sources. Infuse presents these as selectable versions before playback, which is useful when a provider returns multiple quality, codec, or source options for the same movie or episode.
+
+Enable **Media source selection** in Settings to offer source choices. By default Fetcherr keeps automatic playback behavior and selects a stream itself. The Settings UI also lets you choose whether to offer 5 or 10 sources.
+
 ## Connecting Infuse
 
 Add Fetcherr as a Jellyfin server in Infuse with your server URL and a Fetcherr account. Enable **Library Mode**, **Auto Scan**, and **Install InfuseSync Plugin**.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fetcherr
 
-Fetcherr is a Jellyfin-compatible streaming bridge for Infuse and VidHub that syncs watchlists into a library and resolves playback through Real-Debrid, TorBox, or EasyNews streams returned by AIOStreams.
+Fetcherr is a Jellyfin-compatible streaming bridge for Infuse and VidHub that syncs watchlists into a library and resolves playback through Real-Debrid or TorBox streams returned by Stremio add-ons.
 
 ## Responsible Use
 
@@ -10,7 +10,7 @@ Fetcherr should only be used with media you own, have lawfully obtained, or are 
 
 - Docker
 - TMDB API key
-- Real-Debrid or TorBox API key, or AIOStreams configured with EasyNews
+- Real-Debrid or TorBox API key
 - Stremio add-on with playable streams (e.g. AIOStreams, Comet, Debridio)
 - Optional: TVDB API key, Trakt client ID/secret, MDBList API key
 
@@ -58,7 +58,7 @@ Configure AIOStreams with your provider, then paste the manifest URL into Fetche
 - **Language filter:** Set to your preferred language for pre-filtered results
 - In Fetcherr Settings, set **Stream Ranking** to **Provider Order** to preserve AIOStreams sort
 
-Fetcherr also supports EasyNews streams when they are returned by AIOStreams as direct playable URLs. When AIOStreams returns mixed EasyNews, TorBox, and Real-Debrid candidates, Fetcherr tries EasyNews first, then falls back to TorBox or Real-Debrid.
+Fetcherr also has mediated support for direct playable URLs returned by AIOStreams. For example, if your AIOStreams instance is configured with EasyNews and returns an EasyNews-backed stream URL, Fetcherr can unwrap and play that URL through the normal playback resolver. When AIOStreams returns mixed direct URL, TorBox, and Real-Debrid candidates, Fetcherr can try the direct URL first, then fall back to TorBox or Real-Debrid.
 
 ## Search Results
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For shows, Fetcherr hydrates search results into seasons and aired episodes so c
 
 ## Media Source Selection
 
-Fetcherr can optionally expose multiple cached stream candidates as Jellyfin media sources. Infuse presents these as selectable versions before playback, which is useful when a provider returns multiple quality, codec, or source options for the same movie or episode.
+Fetcherr can optionally expose multiple cached stream candidates as Jellyfin media sources. Infuse presents these as selectable versions before playback (long press on play button), which is useful when a provider returns multiple quality, codec, or source options for the same movie or episode.
 
 Enable **Media source selection** in Settings to offer source choices. By default Fetcherr keeps automatic playback behavior and selects a stream itself. The Settings UI also lets you choose whether to offer 5 or 10 sources.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetcherr",
-  "version": "1.5.5",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetcherr",
-      "version": "1.5.5",
+      "version": "1.7.0",
       "dependencies": {
         "better-sqlite3": "^11.0.0",
         "fastify": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fetcherr",
       "version": "1.7.0",
       "dependencies": {
+        "@viren070/parse-torrent-title": "^0.7.6",
         "better-sqlite3": "^11.0.0",
         "fastify": "^5.0.0"
       },
@@ -596,6 +597,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@viren070/parse-torrent-title": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@viren070/parse-torrent-title/-/parse-torrent-title-0.7.6.tgz",
+      "integrity": "sha512-5tHKCKg7QmrloP2irVyPrZSDTRVPr8ELacWzJoHzsJEWUnVQSxrsmlh+S9F04d3Y6ajvPn+vBwGZonJRhyAXHw==",
+      "license": "MIT"
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fetcherr",
   "version": "1.7.0",
-  "description": "Jellyfin-compatible bridge for Infuse with Trakt library sync and Real-Debrid, TorBox, and EasyNews stream resolution.",
+  "description": "Jellyfin-compatible bridge for Infuse with Trakt library sync and Real-Debrid or TorBox stream resolution.",
   "type": "module",
   "scripts": {
     "build": "tsc && mkdir -p dist/ui/static && cp src/ui/*.html dist/ui/ && cp -R src/ui/static/. dist/ui/static/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fetcherr",
   "version": "1.7.0",
+  "description": "Jellyfin-compatible bridge for Infuse with Trakt library sync and Real-Debrid, TorBox, and EasyNews stream resolution.",
   "type": "module",
   "scripts": {
     "build": "tsc && mkdir -p dist/ui/static && cp src/ui/*.html dist/ui/ && cp -R src/ui/static/. dist/ui/static/",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && mkdir -p dist/ui/static && cp src/ui/*.html dist/ui/ && cp -R src/ui/static/. dist/ui/static/",
+    "mock:jellyfin": "node scripts/mock-jellyfin-client.mjs",
     "start": "node dist/index.js",
     "dev": "node --watch --import tsx/esm src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "node --watch --import tsx/esm src/index.ts"
   },
   "dependencies": {
+    "@viren070/parse-torrent-title": "^0.7.6",
     "better-sqlite3": "^11.0.0",
     "fastify": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcherr",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "build": "tsc && mkdir -p dist/ui/static && cp src/ui/*.html dist/ui/ && cp -R src/ui/static/. dist/ui/static/",

--- a/scripts/mock-jellyfin-client.mjs
+++ b/scripts/mock-jellyfin-client.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+const baseUrl = (process.env.FETCHERR_URL || 'http://127.0.0.1:9990').replace(/\/$/, '')
+const mediaKind = (process.env.JELLYFIN_MOCK_MEDIA || 'movie').toLowerCase()
+const movieSearchTerm = process.env.JELLYFIN_MOCK_MOVIE || 'Killers of the Flower Moon'
+const seriesSearchTerm = process.env.JELLYFIN_MOCK_SERIES || 'Game of Thrones'
+const requestedSourceIndex = Number.parseInt(process.env.JELLYFIN_MOCK_SOURCE_INDEX || '0', 10)
+const rangeHeader = process.env.JELLYFIN_MOCK_RANGE || 'bytes=0-1023'
+const minMediaSources = Number.parseInt(process.env.JELLYFIN_MOCK_MIN_SOURCES || '2', 10)
+const maxMediaSources = Number.parseInt(process.env.JELLYFIN_MOCK_MAX_SOURCES || '10', 10)
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(`Usage: npm run mock:jellyfin
+
+Environment:
+  FETCHERR_URL                  Fetcherr base URL, default http://127.0.0.1:9990
+  JELLYFIN_TOKEN                Existing Jellyfin access token
+  JELLYFIN_USERNAME/PASSWORD    Credentials used when no token is supplied
+  JELLYFIN_MOCK_MEDIA           movie, episode, or all; default movie
+  JELLYFIN_MOCK_MOVIE           Movie search term; default Killers of the Flower Moon
+  JELLYFIN_MOCK_SERIES          Series search term; default Game of Thrones
+  JELLYFIN_MOCK_SOURCE_INDEX    MediaSource index to play; default 0
+  JELLYFIN_MOCK_MAX_SOURCES     Maximum expected MediaSources; default 10
+`)
+  process.exit(0)
+}
+
+if (!['movie', 'episode', 'all'].includes(mediaKind)) {
+  fail('JELLYFIN_MOCK_MEDIA must be movie, episode, or all')
+}
+
+function fail(message) {
+  console.error(`mock-jellyfin: ${message}`)
+  process.exit(1)
+}
+
+async function request(path, options = {}) {
+  const url = path.startsWith('http') ? path : `${baseUrl}${path}`
+  const res = await fetch(url, options)
+  const text = await res.text()
+  if (!res.ok) {
+    throw new Error(`${options.method || 'GET'} ${url} returned ${res.status}: ${text.slice(0, 500)}`)
+  }
+  return text ? JSON.parse(text) : {}
+}
+
+async function authenticate() {
+  if (process.env.JELLYFIN_TOKEN) return process.env.JELLYFIN_TOKEN
+
+  const username = process.env.JELLYFIN_USERNAME
+  const password = process.env.JELLYFIN_PASSWORD
+  if (!username || !password) {
+    fail('set JELLYFIN_TOKEN, or set JELLYFIN_USERNAME and JELLYFIN_PASSWORD')
+  }
+
+  const auth = await request('/Users/AuthenticateByName', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-emby-authorization': 'MediaBrowser Client="Fetcherr Mock", Device="CLI", DeviceId="fetcherr-mock", Version="1.0"',
+    },
+    body: JSON.stringify({ Username: username, Pw: password }),
+  })
+
+  if (!auth.AccessToken) fail('authentication response did not include AccessToken')
+  return auth.AccessToken
+}
+
+async function jellyfin(token, path) {
+  return request(path, {
+    headers: {
+      'x-emby-token': token,
+      'x-emby-client': 'Fetcherr Mock',
+      'x-emby-device-name': 'CLI',
+      'x-emby-device-id': 'fetcherr-mock',
+    },
+  })
+}
+
+async function getUserId(token) {
+  if (process.env.JELLYFIN_USER_ID) return process.env.JELLYFIN_USER_ID
+  const user = await jellyfin(token, '/Users/Me')
+  if (!user.Id) fail('/Users/Me did not return a user Id')
+  return user.Id
+}
+
+function assertMediaSources(itemName, sources) {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    fail(`${itemName} did not return any MediaSources`)
+  }
+  if (Number.isFinite(minMediaSources) && sources.length < minMediaSources) {
+    fail(`${itemName} returned ${sources.length} MediaSources; expected at least ${minMediaSources}`)
+  }
+  if (Number.isFinite(maxMediaSources) && sources.length > maxMediaSources) {
+    fail(`${itemName} returned ${sources.length} MediaSources; expected at most ${maxMediaSources}`)
+  }
+  for (const source of sources) {
+    if (!source.Path) fail(`${itemName} returned a MediaSource without Path`)
+    if (!source.Id) fail(`${itemName} returned a MediaSource without Id`)
+  }
+}
+
+async function selectMovie(token, userId) {
+  const search = await jellyfin(
+    token,
+    `/Users/${encodeURIComponent(userId)}/Items?SearchTerm=${encodeURIComponent(movieSearchTerm)}&IncludeItemTypes=Movie&Recursive=true&Limit=10`,
+  )
+  const item = search.Items?.find(candidate => candidate.Type === 'Movie' && candidate.IsPlayable) ?? search.Items?.[0]
+  if (!item) fail(`movie search returned no results for "${movieSearchTerm}"`)
+  return item
+}
+
+async function selectEpisode(token, userId) {
+  const search = await jellyfin(
+    token,
+    `/Users/${encodeURIComponent(userId)}/Items?SearchTerm=${encodeURIComponent(seriesSearchTerm)}&IncludeItemTypes=Series&Recursive=true&Limit=10`,
+  )
+  const series = search.Items?.find(candidate => candidate.Type === 'Series') ?? search.Items?.[0]
+  if (!series) fail(`series search returned no results for "${seriesSearchTerm}"`)
+
+  const seasons = await jellyfin(
+    token,
+    `/Users/${encodeURIComponent(userId)}/Items?ParentId=${encodeURIComponent(series.Id)}&IncludeItemTypes=Season&Limit=100`,
+  )
+  const season = seasons.Items?.find(candidate => candidate.IndexNumber === 1) ?? seasons.Items?.[0]
+  if (!season) fail(`series "${series.Name}" returned no seasons`)
+
+  const episodes = await jellyfin(
+    token,
+    `/Users/${encodeURIComponent(userId)}/Items?ParentId=${encodeURIComponent(season.Id)}&IncludeItemTypes=Episode&Limit=100`,
+  )
+  const episode = episodes.Items?.find(candidate => candidate.ParentIndexNumber === 1 && candidate.IndexNumber === 1) ?? episodes.Items?.[0]
+  if (!episode) fail(`season "${season.Name}" returned no episodes`)
+  return episode
+}
+
+async function verifyPlayback(token, item, label) {
+  const info = await jellyfin(token, `/Items/${encodeURIComponent(item.Id)}/PlaybackInfo`)
+  assertMediaSources(item.Name, info.MediaSources)
+
+  const sourceIndex = Number.isFinite(requestedSourceIndex)
+    ? Math.max(0, Math.min(requestedSourceIndex, info.MediaSources.length - 1))
+    : 0
+  const source = info.MediaSources[sourceIndex]
+
+  const redirect = await fetch(source.Path, {
+    redirect: 'manual',
+    headers: { range: rangeHeader },
+  })
+  if (redirect.status !== 302) {
+    const text = await redirect.text()
+    fail(`${label} source "${source.Name}" did not redirect to provider; status=${redirect.status} body=${text.slice(0, 300)}`)
+  }
+  const location = redirect.headers.get('location')
+  if (!location) fail(`${label} source "${source.Name}" returned 302 without Location`)
+
+  const media = await fetch(location, {
+    redirect: 'follow',
+    headers: { range: rangeHeader },
+    signal: AbortSignal.timeout(60_000),
+  })
+  const bytes = Buffer.from(await media.arrayBuffer()).length
+  if (![200, 206].includes(media.status)) {
+    fail(`${label} provider URL returned ${media.status}`)
+  }
+  if (bytes <= 0) fail(`${label} provider URL returned no bytes`)
+
+  console.log(JSON.stringify({
+    ok: true,
+    label,
+    item: {
+      id: item.Id,
+      name: item.Name,
+      type: item.Type,
+    },
+    mediaSources: info.MediaSources.map(candidate => ({
+      id: candidate.Id,
+      name: candidate.Name,
+      path: new URL(candidate.Path).pathname,
+      container: candidate.Container,
+    })),
+    selected: {
+      index: sourceIndex,
+      id: source.Id,
+      name: source.Name,
+      redirectHost: new URL(location).host,
+      status: media.status,
+      contentType: media.headers.get('content-type'),
+      contentRange: media.headers.get('content-range'),
+      bytes,
+    },
+  }, null, 2))
+}
+
+const token = await authenticate()
+const userId = await getUserId(token)
+
+if (mediaKind === 'movie' || mediaKind === 'all') {
+  const movie = await selectMovie(token, userId)
+  await verifyPlayback(token, movie, 'movie')
+}
+
+if (mediaKind === 'episode' || mediaKind === 'all') {
+  const episode = await selectEpisode(token, userId)
+  await verifyPlayback(token, episode, 'episode')
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -165,5 +165,6 @@ export const config = {
   englishStreamMode: parseEnglishStreamMode(process.env.ENGLISH_STREAM_MODE ?? ''),
   directPlaybackMode: parseDirectPlaybackMode(process.env.DIRECT_PLAYBACK_MODE),
   streamRankingMode: parseStreamRankingMode(process.env.STREAM_RANKING_MODE),
+  mediaSourceSelection: parseBooleanSetting(process.env.MEDIA_SOURCE_SELECTION, false),
   serverUrl:         (process.env.SERVER_URL ?? 'http://localhost:9990').replace(/\/$/, ''),
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,10 +78,16 @@ export type AudioLanguage =
 export type EnglishStreamMode = 'off' | 'prefer' | 'require'
 export type DirectPlaybackMode = 'off' | 'torrentsOnly' | 'all'
 export type StreamRankingMode = 'fetcherr' | 'provider'
+export type MediaSourceLimit = 5 | 10
 
 export function parseStreamRankingMode(value: string | undefined): StreamRankingMode {
   return value === 'provider' ? 'provider' : 'fetcherr'
 }
+
+export function parseMediaSourceLimit(value: string | undefined): MediaSourceLimit {
+  return value === '5' ? 5 : 10
+}
+
 export type ShowAddDefaultMode = 'all' | 'latest'
 export type MovieReleaseMode = 'digital' | 'theatrical'
 
@@ -166,5 +172,6 @@ export const config = {
   directPlaybackMode: parseDirectPlaybackMode(process.env.DIRECT_PLAYBACK_MODE),
   streamRankingMode: parseStreamRankingMode(process.env.STREAM_RANKING_MODE),
   mediaSourceSelection: parseBooleanSetting(process.env.MEDIA_SOURCE_SELECTION, false),
+  mediaSourceLimit: parseMediaSourceLimit(process.env.MEDIA_SOURCE_LIMIT),
   serverUrl:         (process.env.SERVER_URL ?? 'http://localhost:9990').replace(/\/$/, ''),
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -158,6 +158,7 @@ export const config = {
   showAddDefaultMode: parseShowAddDefaultMode(process.env.SHOW_ADD_DEFAULT_MODE),
   movieReleaseMode: parseMovieReleaseMode(process.env.MOVIE_RELEASE_MODE),
   streamProviderUrls: parseStreamProviderUrls(process.env.STREAM_PROVIDER_URLS ?? ''),
+  stremioSearchProviderUrls: [] as string[],
   allowNotWebReadyDirectStreams: parseBooleanSetting(process.env.ALLOW_NOT_WEB_READY_DIRECT_STREAMS, false),
   musicAddonUrls: parseMusicAddonUrls(process.env.MUSIC_ADDON_URLS ?? process.env.MUSIC_ADDON_URL ?? process.env.SPOTIFLAC_URL ?? ''),
   preferredAudioLanguage: parseAudioLanguage(process.env.PREFERRED_AUDIO_LANGUAGE),

--- a/src/db.ts
+++ b/src/db.ts
@@ -190,20 +190,15 @@ export interface TorBoxCleanupJob {
 export const DEFAULT_ADMIN_USER_ID = 'a0000000-0000-0000-0000-000000000002'
 export const MAX_RATING_OPTIONS = [
   'unrestricted',
-  'G',
-  'PG',
-  'PG-13',
-  'R',
-  'NC-17',
-  'TV-Y',
-  'TV-Y7',
-  'TV-G',
-  'TV-PG',
-  'TV-14',
-  'TV-MA',
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
 ] as const
 
 export type MaxRating = typeof MAX_RATING_OPTIONS[number]
+export type RatingLimit = MaxRating
 
 const schema = `
 CREATE TABLE IF NOT EXISTS movies (
@@ -520,10 +515,12 @@ function normalizeUsername(username: string): string {
 }
 
 function normalizeMaxRating(value: string | null | undefined): MaxRating {
-  const normalized = (value ?? '').trim().toUpperCase()
-  if (!normalized) return 'unrestricted'
-  const match = MAX_RATING_OPTIONS.find(option => option.toUpperCase() === normalized)
-  return match ?? 'unrestricted'
+  const raw = (value ?? '').trim()
+  if (!raw) return 'unrestricted'
+  if (['0', '1', '2', '3', '4'].includes(raw)) return raw as MaxRating
+  if (raw.toLowerCase() === 'unrestricted') return 'unrestricted'
+  const severity = ratingSeverity(raw)
+  return severity == null ? 'unrestricted' : String(severity) as MaxRating
 }
 
 function normalizeUserRole(value: string | null | undefined): AppUserRole {
@@ -534,8 +531,8 @@ function normalizeUserRole(value: string | null | undefined): AppUserRole {
 }
 
 function effectiveMaxRatingForRole(role: AppUserRole, maxRating: string): MaxRating {
-  if (role === 'kids') return 'TV-PG'
-  return 'unrestricted'
+  if (role === 'admin') return 'unrestricted'
+  return normalizeMaxRating(maxRating)
 }
 
 function row2appUser(r: Record<string, unknown>): AppUser {
@@ -1641,7 +1638,7 @@ function normalizeOfficialRating(rating: string): string {
   if (!raw) return ''
   const compact = raw.replace(/\s+/g, '').replace(/_/g, '-')
   if (compact === 'TVY') return 'TV-Y'
-  if (compact === 'TVY7' || compact === 'TVY7FV') return 'TV-Y7'
+  if (compact === 'TVY7' || compact === 'TVY7FV' || compact === 'TV-Y7-FV' || compact === 'Y7FV') return 'TV-Y7'
   if (compact === 'TVG') return 'TV-G'
   if (compact === 'TVPG') return 'TV-PG'
   if (compact === 'TV14') return 'TV-14'
@@ -1678,21 +1675,36 @@ function ratingSeverity(rating: string): number | null {
 export function canUserAccessRating(maxRating: string, officialRating: string): boolean {
   const normalizedMax = normalizeMaxRating(maxRating)
   if (normalizedMax === 'unrestricted') return true
-  const limit = ratingSeverity(normalizedMax)
+  const limit = Number.parseInt(normalizedMax, 10)
   const actual = ratingSeverity(officialRating)
-  if (limit == null) return true
+  if (!Number.isFinite(limit)) return true
   if (actual == null) return true
   return actual <= limit
 }
 
+export function canUserAccessKnownRating(maxRating: string, officialRating: string): boolean {
+  const normalizedMax = normalizeMaxRating(maxRating)
+  if (normalizedMax === 'unrestricted') return true
+  const limit = Number.parseInt(normalizedMax, 10)
+  const actual = ratingSeverity(officialRating)
+  if (!Number.isFinite(limit)) return true
+  if (actual == null) return false
+  return actual <= limit
+}
+
+export function hasRatingLimit(user: Pick<AppUser, 'role' | 'maxRating'>): boolean {
+  if (user.role === 'admin') return false
+  return normalizeMaxRating(user.maxRating) !== 'unrestricted'
+}
+
 export function canUserAccessMovie(user: Pick<AppUser, 'role' | 'maxRating'>, movie: Pick<Movie, 'officialRating'>): boolean {
   if (user.role === 'admin') return true
-  return canUserAccessRating(effectiveMaxRatingForRole(user.role, user.maxRating), movie.officialRating)
+  return canUserAccessKnownRating(effectiveMaxRatingForRole(user.role, user.maxRating), movie.officialRating)
 }
 
 export function canUserAccessShow(user: Pick<AppUser, 'role' | 'maxRating'>, show: Pick<Show, 'officialRating'>): boolean {
   if (user.role === 'admin') return true
-  return canUserAccessRating(effectiveMaxRatingForRole(user.role, user.maxRating), show.officialRating)
+  return canUserAccessKnownRating(effectiveMaxRatingForRole(user.role, user.maxRating), show.officialRating)
 }
 
 function row2manualShowSubscription(r: Record<string, unknown>): ManualShowSubscription {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Fastify from 'fastify'
+import { randomBytes } from 'node:crypto'
 import { collectStreamProviderUrls, config, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseEnglishStreamMode, parseMdblistLists, parseMovieReleaseMode, parseMusicAddonUrls, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists } from './config.js'
 import { getDb, getAllSettings } from './db.js'
 import { jellyfinRoutes, resolveJellyfinUser } from './jellyfin/index.js'
@@ -7,7 +8,7 @@ import { wrapFastifyLogger } from './logger.js'
 import { markSyncComplete } from './sync-state.js'
 import { cleanupRemovedTraktListSources, syncTraktWatchlist, syncTraktShowsWatchlist, syncTraktList, syncTraktWatchedStatus, startDeviceAuth, tokenStatus } from './trakt.js'
 import { cleanupRemovedMdblistListSources, normalizeMdblistEntries, syncMdblistList } from './mdblist.js'
-import { fetchRankedStreams, fetchRankedEpisodeStreams, fetchRankedStremioStreams, extractHashFromStream, summarizeStreamForLog, type StremioMediaType } from './sootio.js'
+import { fetchRankedStreams, fetchRankedEpisodeStreams, fetchRankedStremioStreams, extractHashFromStream, summarizeStreamForLog, type StremioMediaType, type Stream } from './sootio.js'
 import { resolveStream, probeAudioLanguages, NotCachedError, ProviderUnavailableError, type ResolvedStream } from './rd.js'
 import {
   markPlaybackStarted as markTorBoxPlaybackStarted,
@@ -18,7 +19,7 @@ import {
 import { getShowByImdbId, getEpisodesForSeason, getLatestSeasonNumberForShow, isEpisodeVisibleToLibrary, listLatestSeasonShowSubscriptions, listMovies, listShows, pruneAllOrphanedMovies, pruneAllOrphanedShows, removeSourceKey, upsertManualShowSubscription } from './db.js'
 import { ensureShowSeasonsCached, refreshShowMetadataIfNeeded, refreshMovieMetadataIfNeeded } from './tmdb.js'
 import { getSessionUser, getTokenFromCookie, isUiAuthConfigured, isValidSession } from './ui/auth.js'
-import { verifySignedPlaybackPath } from './play-auth.js'
+import { createSignedPlaybackUrl, verifySignedPlaybackPath } from './play-auth.js'
 import { hasAudioLanguage, hasNonPreferredAudioMarker, hasPreferredAudioMarker } from './streamLanguage.js'
 import { streamMetadataText } from './streamUtils.js'
 
@@ -93,6 +94,7 @@ getDb()
   if (s.preferredAudioLanguage != null) config.preferredAudioLanguage = parseAudioLanguage(s.preferredAudioLanguage)
   if (s.englishStreamMode != null) config.englishStreamMode = parseEnglishStreamMode(s.englishStreamMode)
   if (s.streamRankingMode != null) config.streamRankingMode = parseStreamRankingMode(s.streamRankingMode)
+  if (s.mediaSourceSelection != null) config.mediaSourceSelection = parseBooleanSetting(s.mediaSourceSelection, false)
   const bothConfigured = Boolean(config.rdApiKey && config.torBoxApiKey)
   if (bothConfigured) {
     config.streamProviderUrls = collectStreamProviderUrls(
@@ -186,9 +188,12 @@ type PlaybackPrewarmEntry = { expiresAt: number; promise: Promise<PlayResolution
 const playbackPrewarmCache = new Map<string, PlaybackPrewarmEntry>()
 let activePlaybackPrewarmPath: string | null = null
 const PLAYBACK_ITEM_TTL_MS = 6 * 60 * 60 * 1000
+const PLAYBACK_CANDIDATE_TTL_MS = 10 * 60 * 1000
+const PLAYBACK_MEDIA_SOURCE_LIMIT = 5
 const playbackItemPaths = new Map<string, { playPath: string; expiresAt: number }>()
 const playbackClientNames = new Map<string, { clientName: string; expiresAt: number }>()
 const torBoxPlaybackUrls = new Map<string, { url: string; expiresAt: number }>()
+const playbackCandidates = new Map<string, { stream: Stream; playPath: string; label: string; fileHint?: string; expiresAt: number }>()
 
 class PlaybackResolutionError extends Error {
   constructor(
@@ -234,6 +239,9 @@ function cleanupPlaybackPrewarmCache() {
   }
   for (const [key, entry] of torBoxPlaybackUrls) {
     if (entry.expiresAt <= now) torBoxPlaybackUrls.delete(key)
+  }
+  for (const [key, entry] of playbackCandidates) {
+    if (entry.expiresAt <= now) playbackCandidates.delete(key)
   }
 }
 
@@ -426,6 +434,11 @@ function directStreamConflictsWithActiveDebrid(stream: { name?: string; title?: 
 
 function streamClearlyDirectDebrid(stream: { name?: string; title?: string; description?: string; behaviorHints?: Record<string, unknown> }): boolean {
   return streamClearlyRealDebridCached(stream) || streamClearlyTorBoxCached(stream)
+}
+
+function streamEligibleForMediaSourceSelection(stream: { name?: string; title?: string; description?: string; behaviorHints?: Record<string, unknown> }): boolean {
+  const text = streamMetadataText(stream)
+  return streamClearlyDirectDebrid(stream) || /\bcached\b|\binstant\b|⚡/.test(text)
 }
 
 function streamMarkedNotWebReady(stream: { behaviorHints?: Record<string, unknown> }): boolean {
@@ -962,6 +975,273 @@ async function resolvePlayableStream(
   return { url: best.url }
 }
 
+function rememberPlaybackCandidate(playPath: string, label: string, stream: Stream, fileHint?: string): string {
+  cleanupPlaybackPrewarmCache()
+  const token = randomBytes(16).toString('hex')
+  playbackCandidates.set(token, {
+    stream,
+    playPath,
+    label,
+    fileHint,
+    expiresAt: Date.now() + PLAYBACK_CANDIDATE_TTL_MS,
+  })
+  return token
+}
+
+function getPlaybackCandidate(token: string | undefined, playPath: string) {
+  cleanupPlaybackPrewarmCache()
+  if (!token) return null
+  const entry = playbackCandidates.get(token)
+  if (!entry || entry.playPath !== playPath) return null
+  return entry
+}
+
+function streamOptionName(stream: Stream, fallbackName: string, index: number): string {
+  const text = `${stream.name ?? ''} ${stream.title ?? ''} ${stream.description ?? ''} ${typeof stream.behaviorHints?.filename === 'string' ? stream.behaviorHints.filename : ''}`
+  const provider = streamProviderName(stream, index)
+  const displayTitle = stremioFormattedStreamTitle(stream)
+  const quality = [
+    normalizedResolutionLabel(text),
+    normalizedSourceLabel(text),
+    normalizedCodecLabel(text),
+    text.match(/(\d+(?:\.\d+)?)\s*(TB|GB|MB)\b/i)?.[0],
+  ].filter(Boolean).join(' ')
+  const title = displayTitle || stream.description || stream.name || fallbackName
+  return sanitizeMediaSourceText([quality, provider, title].filter(Boolean).join(' - ')).slice(0, 180) || `Option ${index + 1}`
+}
+
+function stremioFormattedStreamTitle(stream: Stream): string {
+  const filename = typeof stream.behaviorHints?.filename === 'string' ? stream.behaviorHints.filename : ''
+  const title = stream.title || ''
+  if (!title) return ''
+  return title
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && (!filename || !line.includes(filename)))
+    .join(' ')
+}
+
+function streamProviderName(stream: Stream, index: number): string {
+  const name = stream.name ?? ''
+  const bracket = name.match(/^\[[^\]]+\]\s*([^0-9\n\r]+)/)
+  if (bracket?.[1]?.trim()) return bracket[1].trim()
+  if (name.trim()) return name.trim()
+  if (stream.providerLabel) return stream.providerLabel.replace(/^provider#\d+\s+/, '').split('/')[0] || `Option ${index + 1}`
+  return `Option ${index + 1}`
+}
+
+function normalizedResolutionLabel(text: string): string | undefined {
+  if (/\b(2160p|4k|uhd)\b/i.test(text)) return '2160p'
+  if (/\b1080p\b/i.test(text)) return '1080p'
+  if (/\b720p\b/i.test(text)) return '720p'
+  if (/\b480p\b/i.test(text)) return '480p'
+  return undefined
+}
+
+function normalizedSourceLabel(text: string): string | undefined {
+  if (/\bremux\b/i.test(text)) return 'REMUX'
+  if (/\bblu[ -]?ray\b|\bbdrip\b/i.test(text)) return 'BluRay'
+  if (/\bweb[ ._-]?dl\b/i.test(text)) return 'WEB-DL'
+  if (/\bweb[ ._-]?rip\b/i.test(text)) return 'WEBRip'
+  if (/\bhdtv\b/i.test(text)) return 'HDTV'
+  return undefined
+}
+
+function normalizedCodecLabel(text: string): string | undefined {
+  if (/\bav1\b/i.test(text)) return 'AV1'
+  if (/\bhevc\b|h\.?265\b|x265\b/i.test(text)) return 'HEVC'
+  if (/\bh\.?264\b|x264\b|avc\b/i.test(text)) return 'H.264'
+  return undefined
+}
+
+function sanitizeMediaSourceText(value: string): string {
+  return value
+    .replace(/[\uD800-\uDFFF]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function appendCandidateToSignedUrl(url: string, candidate: string): string {
+  const signed = new URL(url)
+  signed.searchParams.set('candidate', candidate)
+  return signed.toString()
+}
+
+function streamSizeBytes(stream: Stream): number | undefined {
+  if (typeof stream.behaviorHints?.videoSize === 'number' && Number.isFinite(stream.behaviorHints.videoSize)) {
+    return stream.behaviorHints.videoSize
+  }
+  const match = `${stream.name} ${stream.title} ${stream.description ?? ''}`.match(/(\d+(?:\.\d+)?)\s*(TB|GB|MB|KB)/i)
+  if (!match) return undefined
+  const value = Number.parseFloat(match[1])
+  switch (match[2].toUpperCase()) {
+    case 'TB': return Math.round(value * 1e12)
+    case 'GB': return Math.round(value * 1e9)
+    case 'MB': return Math.round(value * 1e6)
+    case 'KB': return Math.round(value * 1e3)
+    default: return undefined
+  }
+}
+
+function streamContainer(stream: Stream): string {
+  const text = streamMetadataText(stream)
+  const match = text.match(/\.(mkv|mp4|m4v|avi|mov|wmv|webm|ts|m2ts)(?:\b|$)/i)
+  return (match?.[1] ?? 'mkv').toLowerCase()
+}
+
+function streamVideoCodec(stream: Stream): string {
+  const text = streamMetadataText(stream)
+  if (/\bav1\b/i.test(text)) return 'av1'
+  if (/\bhevc\b|h\.?265\b|x265\b/i.test(text)) return 'hevc'
+  if (/\bh\.?264\b|x264\b|avc\b/i.test(text)) return 'h264'
+  return 'h264'
+}
+
+function streamVideoDimensions(stream: Stream): { width: number; height: number } {
+  const text = streamMetadataText(stream)
+  if (/\b(2160p|4k|uhd)\b/i.test(text)) return { width: 3840, height: 2160 }
+  if (/\b1080p\b/i.test(text)) return { width: 1920, height: 1080 }
+  if (/\b720p\b/i.test(text)) return { width: 1280, height: 720 }
+  if (/\b480p\b/i.test(text)) return { width: 854, height: 480 }
+  return { width: 1920, height: 1080 }
+}
+
+function streamBitrate(sizeBytes: number | undefined, runtimeTicks: number): number | undefined {
+  if (!sizeBytes || runtimeTicks <= 0) return undefined
+  const seconds = runtimeTicks / 10_000_000
+  if (seconds <= 0) return undefined
+  return Math.round((sizeBytes * 8) / seconds)
+}
+
+function playbackMediaSource(id: string, name: string, path: string, runtimeTicks: number, stream?: Stream) {
+  const size = stream ? streamSizeBytes(stream) : undefined
+  const bitrate = streamBitrate(size, runtimeTicks)
+  const { width, height } = stream ? streamVideoDimensions(stream) : { width: 1920, height: 1080 }
+  const videoCodec = stream ? streamVideoCodec(stream) : 'h264'
+  const container = stream ? streamContainer(stream) : 'mkv'
+  return {
+    Id:                   id,
+    Name:                 name,
+    Type:                 'Default',
+    Protocol:             'Http',
+    Path:                 path,
+    IsRemote:             true,
+    SupportsDirectPlay:   true,
+    SupportsDirectStream: true,
+    SupportsTranscoding:  false,
+    RequiresOpening:      false,
+    RequiresClosing:      false,
+    Container:            container,
+    Size:                 size,
+    Bitrate:              bitrate,
+    VideoType:            'VideoFile',
+    RunTimeTicks:         runtimeTicks,
+    DefaultAudioStreamIndex: 1,
+    MediaStreams: [
+      {
+        Type: 'Video',
+        Index: 0,
+        Codec: videoCodec,
+        IsDefault: true,
+        Width: width,
+        Height: height,
+        BitRate: bitrate,
+        RealFrameRate: 23.976,
+        AverageFrameRate: 23.976,
+      },
+      { Type: 'Audio', Index: 1, Codec: 'aac', IsDefault: true, Language: 'eng' },
+    ],
+  }
+}
+
+async function playbackStreamsForPath(playPath: string, playbackClient: string): Promise<{ streams: Stream[]; label: string; fileHint?: string }> {
+  const stremioMatch = playPath.match(/^\/play\/stremio\/(movie|series)\/(.+)$/)
+  if (stremioMatch) {
+    const mediaType = stremioMatch[1] as StremioMediaType
+    const externalId = decodeURIComponent(stremioMatch[2])
+    return {
+      streams: await fetchRankedStremioStreams(mediaType, externalId, undefined, config.preferredAudioLanguage, '', playbackClient, true),
+      label: `${mediaType} ${externalId}`,
+    }
+  }
+
+  const episodeMatch = playPath.match(/^\/play\/([^/]+)\/(\d+)\/(\d+)$/)
+  if (episodeMatch) {
+    const imdbId = episodeMatch[1]
+    const season = Number.parseInt(episodeMatch[2], 10)
+    const episodeNumber = Number.parseInt(episodeMatch[3], 10)
+    const show = getShowByImdbId(imdbId)
+    const episode = show
+      ? getEpisodesForSeason(show.tmdbId, season).find(ep => ep.episodeNumber === episodeNumber)
+      : null
+    const episodeAirYear = episode?.airDate ? Number.parseInt(episode.airDate.slice(0, 4), 10) : undefined
+    return {
+      streams: await fetchRankedEpisodeStreams(
+        imdbId,
+        season,
+        episodeNumber,
+        show?.year || undefined,
+        Number.isFinite(episodeAirYear) ? episodeAirYear : undefined,
+        config.preferredAudioLanguage,
+        '',
+        playbackClient,
+        true,
+      ),
+      label: `${imdbId} S${season}E${episodeNumber}`,
+      fileHint: `s${pad2(season)}e${pad2(episodeNumber)}`,
+    }
+  }
+
+  const movieMatch = playPath.match(/^\/play\/([^/]+)$/)
+  if (movieMatch) {
+    const imdbId = movieMatch[1]
+    return {
+      streams: await fetchRankedStreams(imdbId, config.preferredAudioLanguage, '', playbackClient, true),
+      label: imdbId,
+    }
+  }
+
+  throw new Error(`Unsupported play path: ${playPath}`)
+}
+
+async function buildPlaybackMediaSources(input: {
+  itemId: string
+  sourceId: string
+  origin: string
+  playPath: string
+  name: string
+  runtimeTicks: number
+  playbackClient: string
+}) {
+  const fallbackUrl = createSignedPlaybackUrl(input.origin, input.playPath)
+  const fallbackSource = playbackMediaSource(input.sourceId, input.name, fallbackUrl, input.runtimeTicks)
+
+  try {
+    const { streams, label, fileHint } = await playbackStreamsForPath(input.playPath, input.playbackClient)
+    const usable = streams
+      .filter(stream => (stream.url || extractHashFromStream(stream)) && streamEligibleForMediaSourceSelection(stream))
+      .slice(0, PLAYBACK_MEDIA_SOURCE_LIMIT)
+
+    if (!usable.length) return [fallbackSource]
+
+    return usable.map((stream, index) => {
+      const candidate = rememberPlaybackCandidate(input.playPath, label, stream, fileHint)
+      const sourceId = `${input.itemId}:candidate:${candidate}`
+      const sourceName = streamOptionName(stream, input.name, index)
+      return playbackMediaSource(
+        sourceId,
+        sourceName,
+        appendCandidateToSignedUrl(createSignedPlaybackUrl(input.origin, input.playPath), candidate),
+        input.runtimeTicks,
+        stream,
+      )
+    })
+  } catch (err) {
+    app.log.warn(`playback: failed to build stream options for ${input.name}: ${err}`)
+    return [fallbackSource]
+  }
+}
+
 async function resolveMoviePlayback(imdbId: string, playbackClient = ''): Promise<PlayResolution> {
   const playPath = `/play/${imdbId}`
   const streams = await fetchRankedStreams(imdbId, config.preferredAudioLanguage, '', playbackClient, true)
@@ -1008,9 +1288,22 @@ async function resolveEpisodePlayback(imdbId: string, season: number, episodeNum
   )
 }
 
+async function resolvePlaybackCandidate(token: string | undefined, playPath: string): Promise<PlayResolution | null> {
+  const candidate = getPlaybackCandidate(token, playPath)
+  if (!candidate) return null
+  app.log.info(`play: resolving selected candidate for ${candidate.label}`)
+  return resolvePlayableStream(
+    [candidate.stream],
+    candidate.label,
+    `${playPath}:candidate:${token}`,
+    candidate.fileHint,
+    true,
+  )
+}
+
 app.get('/play/stremio/:mediaType/:externalId', async (req, reply) => {
   const { mediaType, externalId } = req.params as { mediaType: StremioMediaType; externalId: string }
-  const query = req.query as { token?: string; expires?: string } | undefined
+  const query = req.query as { token?: string; expires?: string; candidate?: string } | undefined
   if (mediaType !== 'movie' && mediaType !== 'series') {
     return reply.code(404).send({ error: 'Unsupported Stremio media type' })
   }
@@ -1034,9 +1327,12 @@ app.get('/play/stremio/:mediaType/:externalId', async (req, reply) => {
   try {
     const label = `Stremio ${mediaType} ${decodedExternalId}`
     const clientName = playbackClientName(playPath)
-    const { promise, reused } = getOrCreatePlaybackResolution(playPath, label, () => resolveStremioPlayback(mediaType, decodedExternalId, clientName))
-    if (reused) app.log.info(`play: using in-flight resolver for ${label}`)
-    const resolved = await promise
+    const selectedCandidate = await resolvePlaybackCandidate(query?.candidate, playPath)
+    const resolved = selectedCandidate ?? await (async () => {
+      const { promise, reused } = getOrCreatePlaybackResolution(playPath, label, () => resolveStremioPlayback(mediaType, decodedExternalId, clientName))
+      if (reused) app.log.info(`play: using in-flight resolver for ${label}`)
+      return promise
+    })()
     rememberTorBoxPlaybackUrl(playPath, resolved)
     return reply.redirect(resolved.url, 302)
   } catch (err) {
@@ -1051,7 +1347,7 @@ app.get('/play/stremio/:mediaType/:externalId', async (req, reply) => {
 
 app.get('/play/:imdbId', async (req, reply) => {
   const { imdbId } = req.params as { imdbId: string }
-  const query = req.query as { token?: string; expires?: string } | undefined
+  const query = req.query as { token?: string; expires?: string; candidate?: string } | undefined
   const playPath = `/play/${imdbId}`
   if (!verifySignedPlaybackPath(playPath, query?.token, query?.expires)) {
     if (!requestPlaybackUser(req.headers)) {
@@ -1069,9 +1365,12 @@ app.get('/play/:imdbId', async (req, reply) => {
   app.log.info(`play: resolving stream for ${imdbId}`)
   try {
     const clientName = playbackClientName(playPath)
-    const { promise, reused } = getOrCreatePlaybackResolution(playPath, imdbId, () => resolveMoviePlayback(imdbId, clientName))
-    if (reused) app.log.info(`play: using in-flight resolver for ${imdbId}`)
-    const resolved = await promise
+    const selectedCandidate = await resolvePlaybackCandidate(query?.candidate, playPath)
+    const resolved = selectedCandidate ?? await (async () => {
+      const { promise, reused } = getOrCreatePlaybackResolution(playPath, imdbId, () => resolveMoviePlayback(imdbId, clientName))
+      if (reused) app.log.info(`play: using in-flight resolver for ${imdbId}`)
+      return promise
+    })()
     rememberTorBoxPlaybackUrl(playPath, resolved)
     return reply.redirect(resolved.url, 302)
   } catch (err) {
@@ -1086,7 +1385,7 @@ app.get('/play/:imdbId', async (req, reply) => {
 
 app.get('/play/:imdbId/:season/:episode', async (req, reply) => {
   const { imdbId, season, episode } = req.params as { imdbId: string; season: string; episode: string }
-  const query = req.query as { token?: string; expires?: string } | undefined
+  const query = req.query as { token?: string; expires?: string; candidate?: string } | undefined
   const playPath = `/play/${imdbId}/${season}/${episode}`
   if (!verifySignedPlaybackPath(playPath, query?.token, query?.expires)) {
     if (!requestPlaybackUser(req.headers)) {
@@ -1107,9 +1406,12 @@ app.get('/play/:imdbId/:season/:episode', async (req, reply) => {
   try {
     const label = `${imdbId} S${s}E${e}`
     const clientName = playbackClientName(playPath)
-    const { promise, reused } = getOrCreatePlaybackResolution(playPath, label, () => resolveEpisodePlayback(imdbId, s, e, clientName))
-    if (reused) app.log.info(`play: using in-flight resolver for ${label}`)
-    const resolved = await promise
+    const selectedCandidate = await resolvePlaybackCandidate(query?.candidate, playPath)
+    const resolved = selectedCandidate ?? await (async () => {
+      const { promise, reused } = getOrCreatePlaybackResolution(playPath, label, () => resolveEpisodePlayback(imdbId, s, e, clientName))
+      if (reused) app.log.info(`play: using in-flight resolver for ${label}`)
+      return promise
+    })()
     rememberTorBoxPlaybackUrl(playPath, resolved)
     return reply.redirect(resolved.url, 302)
   } catch (err) {
@@ -1122,8 +1424,8 @@ app.get('/play/:imdbId/:season/:episode', async (req, reply) => {
   }
 })
 
-await app.register(jellyfinRoutes, { prewarmPlayback, registerPlaybackItem, registerPlaybackClient, touchPlaybackItem, stopPlaybackItem })
-await app.register(jellyfinRoutes, { prefix: '/emby', prewarmPlayback, registerPlaybackItem, registerPlaybackClient, touchPlaybackItem, stopPlaybackItem })
+await app.register(jellyfinRoutes, { prewarmPlayback, registerPlaybackItem, registerPlaybackClient, touchPlaybackItem, stopPlaybackItem, buildPlaybackMediaSources })
+await app.register(jellyfinRoutes, { prefix: '/emby', prewarmPlayback, registerPlaybackItem, registerPlaybackClient, touchPlaybackItem, stopPlaybackItem, buildPlaybackMediaSources })
 await app.register(uiRoutes)
 
 // ── Trakt auth ────────────────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Fastify from 'fastify'
 import { randomBytes } from 'node:crypto'
-import { collectStreamProviderUrls, config, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseEnglishStreamMode, parseMdblistLists, parseMovieReleaseMode, parseMusicAddonUrls, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists } from './config.js'
+import { collectStreamProviderUrls, config, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseEnglishStreamMode, parseMdblistLists, parseMediaSourceLimit, parseMovieReleaseMode, parseMusicAddonUrls, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists } from './config.js'
 import { getDb, getAllSettings } from './db.js'
 import { jellyfinRoutes, resolveJellyfinUser } from './jellyfin/index.js'
 import { uiRoutes } from './ui/routes.js'
@@ -95,6 +95,7 @@ getDb()
   if (s.englishStreamMode != null) config.englishStreamMode = parseEnglishStreamMode(s.englishStreamMode)
   if (s.streamRankingMode != null) config.streamRankingMode = parseStreamRankingMode(s.streamRankingMode)
   if (s.mediaSourceSelection != null) config.mediaSourceSelection = parseBooleanSetting(s.mediaSourceSelection, false)
+  if (s.mediaSourceLimit != null) config.mediaSourceLimit = parseMediaSourceLimit(s.mediaSourceLimit)
   const bothConfigured = Boolean(config.rdApiKey && config.torBoxApiKey)
   if (bothConfigured) {
     config.streamProviderUrls = collectStreamProviderUrls(
@@ -189,7 +190,6 @@ const playbackPrewarmCache = new Map<string, PlaybackPrewarmEntry>()
 let activePlaybackPrewarmPath: string | null = null
 const PLAYBACK_ITEM_TTL_MS = 6 * 60 * 60 * 1000
 const PLAYBACK_CANDIDATE_TTL_MS = 10 * 60 * 1000
-const PLAYBACK_MEDIA_SOURCE_LIMIT = 5
 const playbackItemPaths = new Map<string, { playPath: string; expiresAt: number }>()
 const playbackClientNames = new Map<string, { clientName: string; expiresAt: number }>()
 const torBoxPlaybackUrls = new Map<string, { url: string; expiresAt: number }>()
@@ -501,7 +501,78 @@ function directUrlHost(url: string): string {
   }
 }
 
+function isAioPlaybackUrl(url: URL): boolean {
+  return /^\/api\/v\d+\/debrid\/playback\//.test(url.pathname)
+}
+
+function configuredAioOrigins(): string[] {
+  const urls = [
+    ...config.streamProviderUrls,
+    ...config.stremioSearchProviderUrls,
+    config.sootioUrl,
+  ]
+  const origins = new Set<string>()
+  for (const value of urls) {
+    if (!value) continue
+    try {
+      origins.add(new URL(value).origin)
+    } catch { /* ignore invalid provider values */ }
+  }
+  return [...origins]
+}
+
+function aioPlaybackRedirectCandidates(url: string): string[] {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return []
+  }
+  if (!isAioPlaybackUrl(parsed)) return []
+
+  const candidates = new Set<string>()
+  for (const origin of configuredAioOrigins()) {
+    try {
+      const candidate = new URL(`${parsed.pathname}${parsed.search}`, origin)
+      if (candidate.origin !== parsed.origin) candidates.add(candidate.toString())
+    } catch { /* ignore invalid origin */ }
+  }
+  candidates.add(parsed.toString())
+  return [...candidates]
+}
+
+async function resolveAioPlaybackRedirectUrl(url: string): Promise<string | null> {
+  const candidates = aioPlaybackRedirectCandidates(url)
+  if (!candidates.length) return null
+
+  for (const candidate of candidates) {
+    try {
+      const res = await fetch(candidate, {
+        method: 'GET',
+        redirect: 'manual',
+        headers: { Range: 'bytes=0-0' },
+        signal: AbortSignal.timeout(10_000),
+      })
+      const location = res.headers.get('location')
+      if (location && res.status >= 300 && res.status < 400) {
+        const resolved = new URL(location, candidate).toString()
+        app.log.info(`play: AIO playback URL unwrapped to ${directUrlHost(resolved)}`)
+        return resolved
+      }
+      app.log.warn(`play: AIO playback unwrap returned ${res.status} from ${directUrlHost(candidate)}`)
+      await res.body?.cancel().catch(() => {})
+    } catch (err) {
+      app.log.warn(`play: AIO playback unwrap failed via ${directUrlHost(candidate)}: ${summarizeProbeError(err)}`)
+    }
+  }
+
+  return null
+}
+
 async function resolveDirectPlaybackUrl(url: string): Promise<string> {
+  const aioRedirect = await resolveAioPlaybackRedirectUrl(url)
+  if (aioRedirect) return aioRedirect
+
   try {
     const res = await fetch(url, {
       method: 'GET',
@@ -750,9 +821,10 @@ async function resolvePlayableStream(
             }
           }
 
-          app.log.info(`play: direct stream selected for ${label}${directFilename ? ` → ${directFilename}` : ''}`)
+          const resolvedUrl = await resolveDirectPlaybackUrl(stream.url)
+          app.log.info(`play: direct stream selected for ${label} from ${directUrlHost(resolvedUrl)}${directFilename ? ` → ${directFilename}` : ''}`)
           clearFailedPlay(cacheKey)
-          return { url: stream.url, filename: directFilename }
+          return { url: resolvedUrl, filename: directFilename }
         }
 
         app.log.info(`play: trying ${providerLabel} hash ${hash.slice(0, 8)}… for ${label}`)
@@ -1054,6 +1126,119 @@ function normalizedCodecLabel(text: string): string | undefined {
   return undefined
 }
 
+type StreamResolutionBucket = '2160p' | '1080p' | '720p' | '480p' | 'unknown'
+type StreamCodecBucket = 'h265' | 'h264' | 'av1' | 'other'
+type StreamVarietyKey = `${StreamResolutionBucket}:${StreamCodecBucket}`
+
+const STREAM_VARIETY_KEY_PRIORITY: StreamVarietyKey[] = [
+  '2160p:h265',
+  '2160p:h264',
+  '1080p:h265',
+  '1080p:h264',
+  '2160p:av1',
+  '1080p:av1',
+  '2160p:other',
+  '1080p:other',
+  '720p:h265',
+  '720p:h264',
+  '720p:av1',
+  '720p:other',
+  '480p:h265',
+  '480p:h264',
+  '480p:av1',
+  '480p:other',
+  'unknown:h265',
+  'unknown:h264',
+  'unknown:av1',
+  'unknown:other',
+]
+
+function streamResolutionBucket(stream: Stream): StreamResolutionBucket {
+  const text = streamMetadataText(stream)
+  if (/\b(2160p|4k|uhd)\b/i.test(text)) return '2160p'
+  if (/\b1080p\b/i.test(text)) return '1080p'
+  if (/\b720p\b/i.test(text)) return '720p'
+  if (/\b480p\b/i.test(text)) return '480p'
+  return 'unknown'
+}
+
+function streamCodecBucket(stream: Stream): StreamCodecBucket {
+  const text = streamMetadataText(stream)
+  if (/\bhevc\b|h\.?265\b|x265\b/i.test(text)) return 'h265'
+  if (/\bh\.?264\b|x264\b|avc\b/i.test(text)) return 'h264'
+  if (/\bav1\b/i.test(text)) return 'av1'
+  return 'other'
+}
+
+function streamVarietyKey(stream: Stream): StreamVarietyKey {
+  return `${streamResolutionBucket(stream)}:${streamCodecBucket(stream)}`
+}
+
+function selectPlaybackMediaSourceStreams(streams: Stream[], limit: number): Stream[] {
+  if (limit <= 0) return []
+  if (streams.length <= limit) return streams
+
+  const buckets = new Map<StreamVarietyKey, Stream[]>()
+  const firstSeenKeys: StreamVarietyKey[] = []
+  for (const stream of streams) {
+    const key = streamVarietyKey(stream)
+    const bucket = buckets.get(key)
+    if (bucket) {
+      bucket.push(stream)
+    } else {
+      buckets.set(key, [stream])
+      firstSeenKeys.push(key)
+    }
+  }
+
+  const priorityKeys = [
+    ...STREAM_VARIETY_KEY_PRIORITY.filter(key => buckets.has(key)),
+    ...firstSeenKeys.filter(key => !STREAM_VARIETY_KEY_PRIORITY.includes(key)),
+  ]
+  const selected: Stream[] = []
+  const selectedStreams = new Set<Stream>()
+
+  while (selected.length < limit) {
+    let addedInRound = false
+    for (const key of priorityKeys) {
+      const bucket = buckets.get(key)
+      const stream = bucket?.shift()
+      if (!stream || selectedStreams.has(stream)) continue
+      selected.push(stream)
+      selectedStreams.add(stream)
+      addedInRound = true
+      if (selected.length >= limit) break
+    }
+    if (!addedInRound) break
+  }
+
+  if (selected.length < limit) {
+    for (const stream of streams) {
+      if (selectedStreams.has(stream)) continue
+      selected.push(stream)
+      selectedStreams.add(stream)
+      if (selected.length >= limit) break
+    }
+  }
+
+  return selected
+}
+
+function streamBitrateSortValue(stream: Stream, runtimeTicks: number): number {
+  return streamBitrate(streamSizeBytes(stream), runtimeTicks) ?? 0
+}
+
+function sortPlaybackMediaSourceStreamsByBitrate(streams: Stream[], runtimeTicks: number): Stream[] {
+  return streams
+    .map((stream, index) => ({
+      stream,
+      index,
+      bitrate: streamBitrateSortValue(stream, runtimeTicks),
+    }))
+    .sort((a, b) => b.bitrate - a.bitrate || a.index - b.index)
+    .map(entry => entry.stream)
+}
+
 function sanitizeMediaSourceText(value: string): string {
   return value
     .replace(/[\uD800-\uDFFF]/g, '')
@@ -1218,9 +1403,14 @@ async function buildPlaybackMediaSources(input: {
 
   try {
     const { streams, label, fileHint } = await playbackStreamsForPath(input.playPath, input.playbackClient)
-    const usable = streams
-      .filter(stream => (stream.url || extractHashFromStream(stream)) && streamEligibleForMediaSourceSelection(stream))
-      .slice(0, PLAYBACK_MEDIA_SOURCE_LIMIT)
+    const bitrateSorted = sortPlaybackMediaSourceStreamsByBitrate(
+      streams.filter(stream => (stream.url || extractHashFromStream(stream)) && streamEligibleForMediaSourceSelection(stream)),
+      input.runtimeTicks,
+    )
+    const usable = sortPlaybackMediaSourceStreamsByBitrate(
+      selectPlaybackMediaSourceStreams(bitrateSorted, config.mediaSourceLimit),
+      input.runtimeTicks,
+    )
 
     if (!usable.length) return [fallbackSource]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Fastify from 'fastify'
+import { parseTorrentTitle, type ParsedResult as ParsedTorrentTitleResult } from '@viren070/parse-torrent-title'
 import { randomBytes } from 'node:crypto'
 import { collectStreamProviderUrls, config, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseEnglishStreamMode, parseMdblistLists, parseMediaSourceLimit, parseMovieReleaseMode, parseMusicAddonUrls, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists } from './config.js'
 import { getDb, getAllSettings } from './db.js'
@@ -1069,17 +1070,175 @@ function getPlaybackCandidate(token: string | undefined, playPath: string) {
 }
 
 function streamOptionName(stream: Stream, fallbackName: string, index: number): string {
-  const text = `${stream.name ?? ''} ${stream.title ?? ''} ${stream.description ?? ''} ${typeof stream.behaviorHints?.filename === 'string' ? stream.behaviorHints.filename : ''}`
+  const text = rawStreamMetadataText(stream)
+  const parsed = parseStreamMetadata(stream, text)
+  const tokens = dedupeMediaSourceTokens([
+    compactCacheLabel(stream),
+    compactResolutionLabel(parsed, text),
+    compactSourceLabel(parsed, text),
+    compactCodecLabel(parsed, text),
+    compactHdrLabel(parsed, text),
+    compactFeatureLabel(parsed, text),
+    compactAudioLabel(parsed, text),
+    compactSizeLabel(stream, parsed),
+    compactProviderLabel(stream, index),
+  ])
+  const compact = sanitizeMediaSourceText(tokens.join(' '))
+  if (compact) return compact.slice(0, 64)
+  const title = stremioFormattedStreamTitle(stream) || stream.description || stream.name || fallbackName
+  return sanitizeMediaSourceText(title).slice(0, 64) || `Option ${index + 1}`
+}
+
+function rawStreamMetadataText(stream: Stream): string {
+  const filename = typeof stream.behaviorHints?.filename === 'string' ? stream.behaviorHints.filename : ''
+  return `${stream.name ?? ''} ${stream.title ?? ''} ${stream.description ?? ''} ${filename}`
+}
+
+function parseStreamMetadata(stream: Stream, fallbackText: string): ParsedTorrentTitleResult {
+  const filename = typeof stream.behaviorHints?.filename === 'string' ? stream.behaviorHints.filename : ''
+  const title = stremioFormattedStreamTitle(stream)
+  const parseTarget = filename || title || fallbackText
+  try {
+    return parseTorrentTitle(parseTarget)
+  } catch {
+    return {}
+  }
+}
+
+function dedupeMediaSourceTokens(tokens: Array<string | undefined>): string[] {
+  const seen = new Set<string>()
+  const compact: string[] = []
+  for (const token of tokens) {
+    if (!token) continue
+    const key = token.toLowerCase().replace(/[^a-z0-9+]+/g, '')
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    compact.push(token)
+  }
+  return compact
+}
+
+function compactProviderLabel(stream: Stream, index: number): string | undefined {
   const provider = streamProviderName(stream, index)
-  const displayTitle = stremioFormattedStreamTitle(stream)
-  const quality = [
-    normalizedResolutionLabel(text),
-    normalizedSourceLabel(text),
-    normalizedCodecLabel(text),
-    text.match(/(\d+(?:\.\d+)?)\s*(TB|GB|MB)\b/i)?.[0],
-  ].filter(Boolean).join(' ')
-  const title = displayTitle || stream.description || stream.name || fallbackName
-  return sanitizeMediaSourceText([quality, provider, title].filter(Boolean).join(' - ')).slice(0, 180) || `Option ${index + 1}`
+    .replace(/\bsearch\b/ig, '')
+    .replace(/\bstreams?\b/ig, '')
+    .replace(/\badd-?on\b/ig, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!provider || /^option\s+\d+$/i.test(provider)) return undefined
+  if (/easy\s*news/i.test(provider)) return 'EasyNews'
+  if (/zilean/i.test(provider)) return 'Zilean'
+  if (/real[-\s]?debrid|\brd\b/i.test(provider)) return 'RealDebrid'
+  if (/torbox|\btb\b/i.test(provider)) return 'TorBox'
+  if (/torrentio/i.test(provider)) return 'Torrentio'
+  if (/mediafusion/i.test(provider)) return 'MediaFusion'
+  if (/aio\s*streams?/i.test(provider)) return 'AIOStreams'
+  if (/knight\s*crawler/i.test(provider)) return 'KnightCrawler'
+  if (/jackettio|jackett/i.test(provider)) return 'Jackettio'
+  if (/comet/i.test(provider)) return 'Comet'
+  if (/annatar/i.test(provider)) return 'Annatar'
+  if (/orion/i.test(provider)) return 'Orion'
+  if (/peerflix/i.test(provider)) return 'Peerflix'
+  if (/debridio/i.test(provider)) return 'Debridio'
+  if (/strem\s*thru/i.test(provider)) return 'StremThru'
+  if (/easy\s*debrid/i.test(provider)) return 'EasyDebrid'
+  if (/all\s*debrid/i.test(provider)) return 'AllDebrid'
+  if (/premiumize/i.test(provider)) return 'Premiumize'
+  if (/debrid[-\s]?link/i.test(provider)) return 'DebridLink'
+  if (/put\.?io/i.test(provider)) return 'Putio'
+  return provider.split(/[/:|-]/)[0]?.trim().slice(0, 14) || undefined
+}
+
+function compactCacheLabel(stream: Stream): string | undefined {
+  const text = `${rawStreamMetadataText(stream)} ${stream.url ?? ''} ${(stream.sources ?? []).join(' ')}`.toLowerCase()
+  if (/\[(?:rd|tb)\s+download\]|\bnot\s+ready\b|\buncached\b|⏳/.test(text)) return '⏳'
+  return undefined
+}
+
+function compactResolutionLabel(parsed: ParsedTorrentTitleResult, text: string): string | undefined {
+  const resolution = parsed.resolution ?? ''
+  if (/\b(2160p|4k|uhd)\b/i.test(`${resolution} ${text}`)) return '4K'
+  if (/\b1440p\b/i.test(`${resolution} ${text}`)) return '1440p'
+  if (/\b1080p\b/i.test(`${resolution} ${text}`)) return '1080p'
+  if (/\b720p\b/i.test(`${resolution} ${text}`)) return '720p'
+  if (/\b576p\b/i.test(`${resolution} ${text}`)) return '576p'
+  if (/\b480p\b/i.test(`${resolution} ${text}`)) return '480p'
+  return normalizedResolutionLabel(text)
+}
+
+function compactSourceLabel(parsed: ParsedTorrentTitleResult, text: string): string | undefined {
+  const quality = parsed.quality ?? ''
+  const combined = `${quality} ${text}`
+  if (/\bremux\b/i.test(combined)) return 'Remux'
+  if (/\buntouched\b/i.test(combined)) return 'Untouched'
+  if (/\bblu[ ._-]?ray\b|\bbdrip\b|\bbdremux\b/i.test(combined)) return 'BD'
+  if (/\bweb[ ._-]?dl\b/i.test(combined)) return 'WEB'
+  if (/\bweb[ ._-]?rip\b/i.test(combined)) return 'WEBRip'
+  if (/\bdvd[ ._-]?rip\b|\bdvdrip\b|\bdvd\b/i.test(combined)) return 'DVD'
+  if (/\bhdrip\b/i.test(combined)) return 'HDRip'
+  if (/\bhdtv\b/i.test(combined)) return 'HDTV'
+  return undefined
+}
+
+function compactCodecLabel(parsed: ParsedTorrentTitleResult, text: string): string | undefined {
+  const codec = parsed.codec ?? ''
+  const combined = `${codec} ${text}`
+  if (/\bav1\b/i.test(combined)) return 'AV1'
+  if (/\bhevc\b|h\.?265\b|x265\b/i.test(combined)) return 'HEVC'
+  if (/\bh\.?264\b|x264\b|avc\b/i.test(combined)) return 'H264'
+  if (/\bvc[- .]?1\b/i.test(combined)) return 'VC1'
+  if (/\bxvid\b/i.test(combined)) return 'XviD'
+  return undefined
+}
+
+function compactHdrLabel(parsed: ParsedTorrentTitleResult, text: string): string | undefined {
+  const hdr = (parsed.hdr ?? []).join(' ')
+  const combined = `${hdr} ${text}`
+  if (/\b(?:dolby[ ._-]?vision|dovi|dv)\b/i.test(combined)) return 'DV'
+  if (/\bhdr10\+\b/i.test(combined)) return 'HDR10+'
+  if (/\bhdr10\b/i.test(combined)) return 'HDR10'
+  if (/\bhdr\b/i.test(combined)) return 'HDR'
+  if (/\bsdr\b/i.test(combined)) return 'SDR'
+  return undefined
+}
+
+function compactFeatureLabel(parsed: ParsedTorrentTitleResult, text: string): string | undefined {
+  const editions = (parsed.editions ?? []).join(' ')
+  const combined = `${editions} ${text}`
+  if (/\bimax\b/i.test(combined)) return 'IMAX'
+  if (parsed.upscaled || /\bai[ ._-]*upscale(?:d)?\b|\bupscale(?:d)?\b|\btopaz\b|\brealesrgan\b|\bai\b/i.test(combined)) return 'AI'
+  return undefined
+}
+
+function compactAudioLabel(parsed: ParsedTorrentTitleResult, text: string): string | undefined {
+  const audio = (parsed.audio ?? []).join(' ')
+  const combined = `${audio} ${text}`
+  if (/\batmos\b/i.test(combined)) return 'Atmos'
+  if (/\btruehd\b/i.test(combined)) return 'TrueHD'
+  if (/\bdts[ ._-]?x\b/i.test(combined)) return 'DTS-X'
+  if (/\bdts[ ._-]?hd\b|\bdts\s+lossless\b/i.test(combined)) return 'DTS-HD'
+  if (/\bdd\+|\be-?ac-?3\b/i.test(combined)) return 'DD+'
+  if (/\bdolby[ ._-]?digital\b|\bdd\b|\bac3\b/i.test(combined)) return 'DD'
+  if (/\bflac\b/i.test(combined)) return 'FLAC'
+  if (/\baac\b/i.test(combined)) return 'AAC'
+  return undefined
+}
+
+function compactSizeLabel(stream: Stream, parsed?: ParsedTorrentTitleResult): string | undefined {
+  const nbsp = '\u202F'
+  const bytes = streamSizeBytes(stream)
+  if (bytes && bytes > 0) {
+    if (bytes >= 1e12) return `${Math.round(bytes / 1e11) / 10}${nbsp}TB`
+    if (bytes >= 1e9) return `${Math.round(bytes / 1e9)}${nbsp}GB`
+    if (bytes >= 1e6) return `${Math.round(bytes / 1e6)}${nbsp}MB`
+    if (bytes >= 1e3) return `${Math.round(bytes / 1e3)}${nbsp}KB`
+    return `${bytes}${nbsp}B`
+  }
+  const size = parsed?.size?.match(/(\d+(?:\.\d+)?)\s*(TB|GB|MB|KB|B)/i)
+  if (!size) return undefined
+  const value = Number.parseFloat(size[1])
+  if (!Number.isFinite(value)) return undefined
+  return `${Math.round(value)}${nbsp}${size[2].toUpperCase()}`
 }
 
 function stremioFormattedStreamTitle(stream: Stream): string {
@@ -1242,7 +1401,7 @@ function sortPlaybackMediaSourceStreamsByBitrate(streams: Stream[], runtimeTicks
 function sanitizeMediaSourceText(value: string): string {
   return value
     .replace(/[\uD800-\uDFFF]/g, '')
-    .replace(/\s+/g, ' ')
+    .replace(/[ \t\r\n\f\v\u00A0]+/g, ' ')
     .trim()
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { wrapFastifyLogger } from './logger.js'
 import { markSyncComplete } from './sync-state.js'
 import { cleanupRemovedTraktListSources, syncTraktWatchlist, syncTraktShowsWatchlist, syncTraktList, syncTraktWatchedStatus, startDeviceAuth, tokenStatus } from './trakt.js'
 import { cleanupRemovedMdblistListSources, normalizeMdblistEntries, syncMdblistList } from './mdblist.js'
-import { fetchRankedStreams, fetchRankedEpisodeStreams, extractHashFromStream, summarizeStreamForLog } from './sootio.js'
+import { fetchRankedStreams, fetchRankedEpisodeStreams, fetchRankedStremioStreams, extractHashFromStream, summarizeStreamForLog, type StremioMediaType } from './sootio.js'
 import { resolveStream, probeAudioLanguages, NotCachedError, ProviderUnavailableError, type ResolvedStream } from './rd.js'
 import {
   markPlaybackStarted as markTorBoxPlaybackStarted,
@@ -113,6 +113,13 @@ getDb()
       config.streamProviderUrls.join('\n'),
     )
   }
+  config.stremioSearchProviderUrls = collectStreamProviderUrls(
+    s.rdStreamProviderUrls ?? '',
+    s.torBoxStreamProviderUrls ?? '',
+    s.streamProviderUrls ?? '',
+    config.streamProviderUrls.join('\n'),
+    config.sootioUrl,
+  )
 }
 
 rehydrateTorBoxCleanupJobs()
@@ -298,10 +305,13 @@ function prewarmPlayback(playPath: string, label: string): void {
     return
   }
 
+  const stremioRouteMatch = playPath.match(/^\/play\/stremio\/(movie|series)\/(.+)$/)
   const episodeMatch = playPath.match(/^\/play\/([^/]+)\/(\d+)\/(\d+)$/)
   const movieMatch = playPath.match(/^\/play\/([^/]+)$/)
   const clientName = playbackClientName(playPath)
-  const resolver = episodeMatch
+  const resolver = stremioRouteMatch
+    ? () => resolveStremioPlayback(stremioRouteMatch[1] as StremioMediaType, decodeURIComponent(stremioRouteMatch[2]), clientName)
+    : episodeMatch
     ? () => resolveEpisodePlayback(episodeMatch[1], Number.parseInt(episodeMatch[2], 10), Number.parseInt(episodeMatch[3], 10), clientName)
     : movieMatch
       ? () => resolveMoviePlayback(movieMatch[1], clientName)
@@ -958,6 +968,12 @@ async function resolveMoviePlayback(imdbId: string, playbackClient = ''): Promis
   return resolvePlayableStream(streams, imdbId, playPath, undefined, true)
 }
 
+async function resolveStremioPlayback(mediaType: StremioMediaType, externalId: string, playbackClient = ''): Promise<PlayResolution> {
+  const playPath = `/play/stremio/${mediaType}/${encodeURIComponent(externalId)}`
+  const streams = await fetchRankedStremioStreams(mediaType, externalId, undefined, config.preferredAudioLanguage, '', playbackClient, true)
+  return resolvePlayableStream(streams, `${mediaType} ${externalId}`, playPath, undefined, true)
+}
+
 async function resolveEpisodePlayback(imdbId: string, season: number, episodeNumber: number, playbackClient = ''): Promise<PlayResolution> {
   const playPath = `/play/${imdbId}/${season}/${episodeNumber}`
   const show = getShowByImdbId(imdbId)
@@ -991,6 +1007,47 @@ async function resolveEpisodePlayback(imdbId: string, season: number, episodeNum
     true,
   )
 }
+
+app.get('/play/stremio/:mediaType/:externalId', async (req, reply) => {
+  const { mediaType, externalId } = req.params as { mediaType: StremioMediaType; externalId: string }
+  const query = req.query as { token?: string; expires?: string } | undefined
+  if (mediaType !== 'movie' && mediaType !== 'series') {
+    return reply.code(404).send({ error: 'Unsupported Stremio media type' })
+  }
+  let decodedExternalId: string
+  try { decodedExternalId = decodeURIComponent(externalId) }
+  catch { return reply.code(400).send({ error: 'Invalid external ID encoding' }) }
+  const playPath = `/play/stremio/${mediaType}/${encodeURIComponent(decodedExternalId)}`
+  if (!verifySignedPlaybackPath(playPath, query?.token, query?.expires)) {
+    if (!requestPlaybackUser(req.headers)) {
+      app.log.warn(`play: rejected unauthenticated Stremio playback request for ${mediaType} ${decodedExternalId}`)
+    } else {
+      app.log.warn(`play: rejected unsigned or expired Stremio playback request for ${mediaType} ${decodedExternalId}`)
+    }
+    return reply.code(401).send({ error: 'Unauthorized' })
+  }
+  const failedReason = getFailedPlayReason(playPath)
+  if (failedReason) {
+    app.log.info(`play: cached miss for Stremio ${mediaType} ${decodedExternalId} (${failedReason})`)
+    return reply.code(404).send({ error: failedReason, message: 'No Streams Found' })
+  }
+  try {
+    const label = `Stremio ${mediaType} ${decodedExternalId}`
+    const clientName = playbackClientName(playPath)
+    const { promise, reused } = getOrCreatePlaybackResolution(playPath, label, () => resolveStremioPlayback(mediaType, decodedExternalId, clientName))
+    if (reused) app.log.info(`play: using in-flight resolver for ${label}`)
+    const resolved = await promise
+    rememberTorBoxPlaybackUrl(playPath, resolved)
+    return reply.redirect(resolved.url, 302)
+  } catch (err) {
+    if (err instanceof PlaybackResolutionError) {
+      return reply.code(err.statusCode).send(err.response)
+    }
+    app.log.warn(`play: no Stremio stream for ${mediaType} ${decodedExternalId}: ${err}`)
+    cacheFailedPlay(playPath, 'No streams found')
+    return reply.code(404).send({ error: 'No stream available', message: 'No Streams Found' })
+  }
+})
 
 app.get('/play/:imdbId', async (req, reply) => {
   const { imdbId } = req.params as { imdbId: string }

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import { createHash, randomBytes } from 'node:crypto'
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 import { config } from '../config.js'
 import {
   listMovies, countMovies, getMovieByTmdbId,
@@ -44,7 +46,13 @@ const FOLDER_ID = MOVIES_FOLDER_ID
 const API_LIBRARY_FILTER = { availableOnly: true as const }
 const READ_CACHE_TTL_MS = 3_000
 const IMAGE_PROXY_TTL_MS = 60 * 60 * 1000
+const IMAGE_PROXY_TIMEOUT_MS = 10_000
+const IMAGE_PROXY_MAX_BYTES = 8 * 1024 * 1024
+const IMAGE_PROXY_MAX_REDIRECTS = 5
+const IMAGE_PROXY_CACHE_MAX_ITEMS = 250
 const STREMIO_SEARCH_CACHE_TTL_MS = 30 * 60 * 1000
+const STREMIO_SEARCH_CACHE_MAX_KEYS = 2_000
+const STREMIO_CACHE_MAX_ITEMS = 1_000
 const PLAYED_COMPLETION_THRESHOLD = 0.95
 const NEXT_UP_PROGRESS_THRESHOLD = 0.60
 const JELLYFIN_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000
@@ -138,11 +146,13 @@ function idToTraktCollectionSlug(id: string): string | null {
 }
 
 function stremioSearchMetaIds(meta: StremioMeta, mediaType: StremioMediaType): { itemId: string; sourceId: string } {
+  pruneStremioCaches()
   const itemId = createHash('md5').update(`stremio:item:${mediaType}:${meta.id}`).digest('hex')
   const sourceId = createHash('md5').update(`stremio:source:${mediaType}:${meta.id}`).digest('hex')
   const cached = { meta, mediaType, itemId, sourceId, expiresAt: Date.now() + STREMIO_SEARCH_CACHE_TTL_MS }
   stremioSearchCache.set(itemId, cached)
   stremioSearchCache.set(sourceId, cached)
+  trimStremioSearchCache()
   return { itemId, sourceId }
 }
 
@@ -166,6 +176,7 @@ async function hydrateStremioSeriesMeta(series: StremioMeta): Promise<StremioMet
 }
 
 function idToStremioSearchMeta(id: string): { meta: StremioMeta; mediaType: StremioMediaType; itemId: string; sourceId: string; requestedId: string } | null {
+  pruneStremioCaches()
   if (!/^[0-9a-f]{32}$/i.test(id)) return null
   const cached = stremioSearchCache.get(id)
   if (!cached) return null
@@ -178,13 +189,16 @@ function idToStremioSearchMeta(id: string): { meta: StremioMeta; mediaType: Stre
 }
 
 function stremioSeasonToId(series: StremioMeta, seasonNumber: number): string {
+  pruneStremioCaches()
   const hash = createHash('md5').update(`stremio-season:${series.id}:${seasonNumber}`).digest('hex')
   const id = `00000000-0000-4000-8008-${hash.slice(-12)}`
   stremioSeasonCache.set(id, { series, seasonNumber, expiresAt: Date.now() + STREMIO_SEARCH_CACHE_TTL_MS })
+  trimCacheMap(stremioSeasonCache, STREMIO_CACHE_MAX_ITEMS)
   return id
 }
 
 function idToStremioSeason(id: string): { series: StremioMeta; seasonNumber: number } | null {
+  pruneStremioCaches()
   if (!/^00000000-0000-4000-8008-[0-9a-f]{12}$/i.test(id)) return null
   const cached = stremioSeasonCache.get(id)
   if (!cached) return null
@@ -196,13 +210,16 @@ function idToStremioSeason(id: string): { series: StremioMeta; seasonNumber: num
 }
 
 function stremioEpisodeToId(series: StremioMeta, episode: StremioMeta): string {
+  pruneStremioCaches()
   const hash = createHash('md5').update(`stremio-episode:${series.id}:${episode.id || episode.season}:${episode.episode || episode.number}`).digest('hex')
   const id = `00000000-0000-4000-8009-${hash.slice(-12)}`
   stremioEpisodeCache.set(id, { series, episode, expiresAt: Date.now() + STREMIO_SEARCH_CACHE_TTL_MS })
+  trimCacheMap(stremioEpisodeCache, STREMIO_CACHE_MAX_ITEMS)
   return id
 }
 
 function idToStremioEpisode(id: string): { series: StremioMeta; episode: StremioMeta } | null {
+  pruneStremioCaches()
   if (!/^00000000-0000-4000-8009-[0-9a-f]{12}$/i.test(id)) return null
   const cached = stremioEpisodeCache.get(id)
   if (!cached) return null
@@ -211,6 +228,39 @@ function idToStremioEpisode(id: string): { series: StremioMeta; episode: Stremio
     return null
   }
   return { series: cached.series, episode: cached.episode }
+}
+
+function trimCacheMap<K, V>(cache: Map<K, V>, maxItems: number): void {
+  while (cache.size > maxItems) {
+    const firstKey = cache.keys().next().value as K | undefined
+    if (firstKey === undefined) return
+    cache.delete(firstKey)
+  }
+}
+
+function trimStremioSearchCache(): void {
+  const seen = new Set<object>()
+  for (const entry of stremioSearchCache.values()) {
+    if (stremioSearchCache.size <= STREMIO_SEARCH_CACHE_MAX_KEYS) return
+    if (seen.has(entry)) continue
+    seen.add(entry)
+    stremioSearchCache.delete(entry.itemId)
+    stremioSearchCache.delete(entry.sourceId)
+  }
+}
+
+function pruneStremioCaches(now = Date.now()): void {
+  for (const entry of stremioSearchCache.values()) {
+    if (entry.expiresAt > now) continue
+    stremioSearchCache.delete(entry.itemId)
+    stremioSearchCache.delete(entry.sourceId)
+  }
+  for (const [id, entry] of stremioSeasonCache) {
+    if (entry.expiresAt <= now) stremioSeasonCache.delete(id)
+  }
+  for (const [id, entry] of stremioEpisodeCache) {
+    if (entry.expiresAt <= now) stremioEpisodeCache.delete(id)
+  }
 }
 
 function seasonToId(showTmdbId: number, seasonNum: number): string {
@@ -302,6 +352,135 @@ function bodyString(body: Record<string, unknown> | undefined, keys: string[]): 
   return ''
 }
 
+const ALLOWED_IMAGE_CONTENT_TYPES = new Set([
+  'image/avif',
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/x-icon',
+])
+
+function normalizedHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+}
+
+function ipv4ToNumber(address: string): number | null {
+  const parts = address.split('.').map(part => Number.parseInt(part, 10))
+  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) return null
+  return ((parts[0] << 24) >>> 0) + (parts[1] << 16) + (parts[2] << 8) + parts[3]
+}
+
+function ipv4InCidr(address: string, base: string, bits: number): boolean {
+  const value = ipv4ToNumber(address)
+  const baseValue = ipv4ToNumber(base)
+  if (value == null || baseValue == null) return false
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0
+  return (value & mask) === (baseValue & mask)
+}
+
+function isBlockedIpv4(address: string): boolean {
+  return [
+    ['0.0.0.0', 8],
+    ['10.0.0.0', 8],
+    ['100.64.0.0', 10],
+    ['127.0.0.0', 8],
+    ['169.254.0.0', 16],
+    ['172.16.0.0', 12],
+    ['192.0.0.0', 24],
+    ['192.0.2.0', 24],
+    ['192.168.0.0', 16],
+    ['198.18.0.0', 15],
+    ['198.51.100.0', 24],
+    ['203.0.113.0', 24],
+    ['224.0.0.0', 4],
+    ['240.0.0.0', 4],
+  ].some(([base, bits]) => ipv4InCidr(address, String(base), Number(bits)))
+}
+
+function isBlockedIpv6(address: string): boolean {
+  const lower = address.toLowerCase()
+  if (lower === '::' || lower === '::1') return true
+  const mappedIpv4 = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  if (mappedIpv4) return isBlockedIpv4(mappedIpv4[1])
+  const embeddedIpv4 = lower.match(/(?:^|:)(\d{1,3}(?:\.\d{1,3}){3})$/)
+  if (embeddedIpv4) return isBlockedIpv4(embeddedIpv4[1])
+  const firstHextet = Number.parseInt(lower.split(':')[0] || '0', 16)
+  if (!Number.isFinite(firstHextet)) return true
+  return (firstHextet & 0xfe00) === 0xfc00
+    || (firstHextet & 0xffc0) === 0xfe80
+    || (firstHextet & 0xff00) === 0xff00
+}
+
+function isBlockedIpAddress(address: string): boolean {
+  const normalized = normalizedHostname(address)
+  const version = isIP(normalized)
+  if (version === 4) return isBlockedIpv4(normalized)
+  if (version === 6) return isBlockedIpv6(normalized)
+  return true
+}
+
+async function isPublicHttpUrl(url: URL): Promise<boolean> {
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return false
+  if (url.username || url.password) return false
+
+  const hostname = normalizedHostname(url.hostname)
+  if (!hostname || hostname === 'localhost' || hostname.endsWith('.localhost') || hostname.endsWith('.local')) return false
+  if (isIP(hostname)) return !isBlockedIpAddress(hostname)
+
+  try {
+    const addresses = await lookup(hostname, { all: true, verbatim: true })
+    return addresses.length > 0 && addresses.every(entry => !isBlockedIpAddress(entry.address))
+  } catch {
+    return false
+  }
+}
+
+function imageContentType(raw: string | null): string | null {
+  const contentType = raw?.split(';')[0]?.trim().toLowerCase() ?? ''
+  return ALLOWED_IMAGE_CONTENT_TYPES.has(contentType) ? contentType : null
+}
+
+async function readLimitedResponseBody(res: Response): Promise<Buffer | null> {
+  const rawLength = res.headers.get('content-length')
+  const contentLength = rawLength ? Number.parseInt(rawLength, 10) : 0
+  if (Number.isFinite(contentLength) && contentLength > IMAGE_PROXY_MAX_BYTES) {
+    await res.body?.cancel().catch(() => {})
+    return null
+  }
+
+  if (!res.body) {
+    const buffer = Buffer.from(await res.arrayBuffer())
+    return buffer.length <= IMAGE_PROXY_MAX_BYTES ? buffer : null
+  }
+
+  const chunks: Buffer[] = []
+  let total = 0
+  const reader = res.body.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value) continue
+      total += value.byteLength
+      if (total > IMAGE_PROXY_MAX_BYTES) {
+        await reader.cancel().catch(() => {})
+        return null
+      }
+      chunks.push(Buffer.from(value))
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return Buffer.concat(chunks, total)
+}
+
+function cacheProxiedImage(url: string, value: { buffer: Buffer; contentType: string }, now = Date.now()): void {
+  proxiedImageCache.set(url, { ...value, expiresAt: now + IMAGE_PROXY_TTL_MS })
+  trimCacheMap(proxiedImageCache, IMAGE_PROXY_CACHE_MAX_ITEMS)
+}
+
 async function fetchProxiedImage(url: string): Promise<{ buffer: Buffer; contentType: string } | null> {
   const now = Date.now()
   const cached = proxiedImageCache.get(url)
@@ -310,20 +489,44 @@ async function fetchProxiedImage(url: string): Promise<{ buffer: Buffer; content
   }
 
   try {
-    const res = await fetch(url, {
-      redirect: 'follow',
-      headers: {
-        'user-agent': 'Fetcherr/1.0',
-        'accept': 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8',
-      },
-    })
-    if (!res.ok) return null
+    let current = new URL(url)
+    for (let redirects = 0; redirects <= IMAGE_PROXY_MAX_REDIRECTS; redirects++) {
+      if (!await isPublicHttpUrl(current)) return null
+      const res = await fetch(current, {
+        redirect: 'manual',
+        headers: {
+          'user-agent': 'Fetcherr/1.0',
+          'accept': 'image/avif,image/webp,image/png,image/jpeg,image/gif,image/*;q=0.8',
+        },
+        signal: AbortSignal.timeout(IMAGE_PROXY_TIMEOUT_MS),
+      })
 
-    const arrayBuffer = await res.arrayBuffer()
-    const buffer = Buffer.from(arrayBuffer)
-    const contentType = res.headers.get('content-type') || 'image/jpeg'
-    proxiedImageCache.set(url, { buffer, contentType, expiresAt: now + IMAGE_PROXY_TTL_MS })
-    return { buffer, contentType }
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get('location')
+        await res.body?.cancel().catch(() => {})
+        if (!location) return null
+        current = new URL(location, current)
+        continue
+      }
+
+      if (!res.ok) {
+        await res.body?.cancel().catch(() => {})
+        return null
+      }
+
+      const contentType = imageContentType(res.headers.get('content-type'))
+      if (!contentType) {
+        await res.body?.cancel().catch(() => {})
+        return null
+      }
+
+      const buffer = await readLimitedResponseBody(res)
+      if (!buffer) return null
+      const result = { buffer, contentType }
+      cacheProxiedImage(url, result, now)
+      return result
+    }
+    return null
   } catch {
     return null
   }
@@ -3021,13 +3224,8 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
   app.get('/Videos/:id/stream', async (req, reply) => {
     const { id } = req.params as { id: string }
     const query = req.query as { playSessionId?: string; PlaySessionId?: string; mediaSourceId?: string; MediaSourceId?: string } | undefined
-    const playSessionId = query?.playSessionId ?? query?.PlaySessionId
     const mediaSourceId = query?.mediaSourceId ?? query?.MediaSourceId
-    const sessionMatches = playSessionId === `fetcherr-${id}`
-    const sourceMatches = mediaSourceId === id
-      || Boolean(candidateTokenFromMediaSourceId(mediaSourceId))
-      || idToStremioSearchMeta(id)?.sourceId === mediaSourceId
-    const user = requestUser(req.headers) ?? ((sessionMatches || sourceMatches) ? fallbackUser() : null)
+    const user = requestUser(req.headers)
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
 
     const origin = buildPlaybackOrigin(req.headers as Record<string, string | undefined>)

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -2259,6 +2259,48 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     }
   }
 
+  async function addMovieDetailMediaSources(
+    item: Record<string, unknown>,
+    headers: Record<string, string | string[] | undefined> | undefined,
+    input: {
+      itemId: string
+      sourceId: string
+      imdbId: string
+      name: string
+      runtimeTicks: number
+    },
+  ) {
+    if (!config.mediaSourceSelection) return item
+    return addDetailMediaSources(item, headers, {
+      itemId: input.itemId,
+      sourceId: input.sourceId,
+      playPath: `/play/${input.imdbId}`,
+      name: input.name,
+      runtimeTicks: input.runtimeTicks,
+    })
+  }
+
+  async function addStremioMovieDetailMediaSources(
+    item: Record<string, unknown>,
+    headers: Record<string, string | string[] | undefined> | undefined,
+    input: {
+      itemId: string
+      sourceId: string
+      externalId: string
+      name: string
+      runtimeTicks: number
+    },
+  ) {
+    if (!config.mediaSourceSelection) return item
+    return addDetailMediaSources(item, headers, {
+      itemId: input.itemId,
+      sourceId: input.sourceId,
+      playPath: `/play/stremio/movie/${encodeURIComponent(input.externalId)}`,
+      name: input.name,
+      runtimeTicks: input.runtimeTicks,
+    })
+  }
+
   async function handleItem(
     id: string,
     reply: { code: (n: number) => { send: (v: unknown) => unknown } },
@@ -2326,7 +2368,15 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
         : stremioSearch.meta
       const item = stremioSearchMetaToItem(meta, stremioSearch.mediaType, stremioSearch.requestedId) as Record<string, unknown>
       if (stremioSearch.mediaType !== 'movie') return item
-      return searchMovieAutoplayItem(item)
+      const movieItem = searchMovieAutoplayItem(item)
+      const externalId = meta.imdb_id || meta.imdbId || meta.id
+      return addStremioMovieDetailMediaSources(movieItem, headers, {
+        itemId: stremioSearch.requestedId,
+        sourceId: stremioSearch.sourceId,
+        externalId,
+        name: stremioMetaName(meta),
+        runtimeTicks: stremioRuntimeTicks(meta, 90),
+      })
     }
 
     // Episode
@@ -2397,7 +2447,15 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       if (!movie) return reply.code(404).send({ error: 'Not found' })
       if (!canUserAccessMovie(currentUser, movie)) return reply.code(404).send({ error: 'Not found' })
       const item = movieToSearchItem(movie) as Record<string, unknown>
-      return searchMovieAutoplayItem(item)
+      const movieItem = searchMovieAutoplayItem(item)
+      if (!movie.imdbId || !isMovieVisibleToLibrary(movie)) return movieItem
+      return addMovieDetailMediaSources(movieItem, headers, {
+        itemId: id,
+        sourceId: id,
+        imdbId: movie.imdbId,
+        name: movie.title,
+        runtimeTicks: (movie.runtimeMins || 90) * 60 * 10_000_000,
+      })
     }
 
     const tmdbId = idToTmdb(id)
@@ -2406,7 +2464,15 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const movie = getMovieByTmdbId(tmdbId) ?? await fetchMovieByTmdbId(tmdbId)
     if (!movie) return reply.code(404).send({ error: 'Not found' })
     if (!canUserAccessMovie(currentUser, movie)) return reply.code(404).send({ error: 'Not found' })
-    return movieToItem(movie, currentUser.id)
+    const item = movieToItem(movie, currentUser.id) as Record<string, unknown>
+    if (!movie.imdbId) return item
+    return addMovieDetailMediaSources(item, headers, {
+      itemId: id,
+      sourceId: id,
+      imdbId: movie.imdbId,
+      name: movie.title,
+      runtimeTicks: (movie.runtimeMins || 90) * 60 * 10_000_000,
+    })
   }
 
   app.get('/Items/:id', async (req, reply) => {
@@ -2812,7 +2878,17 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const name = stremioMetaName(meta)
       const runtimeTicks = stremioRuntimeTicks(meta, 90)
       const playbackClient = playbackClientFromHeaders(req.headers)
-      const mediaSources = [defaultPlaybackMediaSource(sourceId, name, playUrl, runtimeTicks)]
+      const mediaSources = config.mediaSourceSelection
+        ? await playbackMediaSourcesFor(opts, {
+            itemId: id,
+            sourceId,
+            origin: buildPlaybackOrigin(req.headers),
+            playPath,
+            name,
+            runtimeTicks,
+            playbackClient,
+          })
+        : [defaultPlaybackMediaSource(sourceId, name, playUrl, runtimeTicks)]
       app.log.info(`playback: Stremio "${name}" → ${playUrl}`)
       opts.registerPlaybackItem?.(id, playPath)
       opts.registerPlaybackClient?.(playPath, playbackClient)
@@ -2881,7 +2957,17 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
       const runtimeTicks = (movie.runtimeMins || 90) * 60 * 10_000_000
       const playbackClient = playbackClientFromHeaders(req.headers)
-      const mediaSources = [defaultPlaybackMediaSource(id, movie.title, playUrl, runtimeTicks)]
+      const mediaSources = config.mediaSourceSelection
+        ? await playbackMediaSourcesFor(opts, {
+            itemId: id,
+            sourceId: id,
+            origin: buildPlaybackOrigin(req.headers),
+            playPath,
+            name: movie.title,
+            runtimeTicks,
+            playbackClient,
+          })
+        : [defaultPlaybackMediaSource(id, movie.title, playUrl, runtimeTicks)]
       app.log.info(`playback: "${movie.title}" → ${playUrl}`)
       opts.registerPlaybackItem?.(id, playPath)
       opts.registerPlaybackClient?.(playPath, playbackClient)
@@ -2906,7 +2992,17 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
     const runtimeTicks = (movie.runtimeMins || 90) * 60 * 10_000_000
     const playbackClient = playbackClientFromHeaders(req.headers)
-    const mediaSources = [defaultPlaybackMediaSource(id, movie.title, playUrl, runtimeTicks)]
+    const mediaSources = config.mediaSourceSelection
+      ? await playbackMediaSourcesFor(opts, {
+          itemId: id,
+          sourceId: id,
+          origin: buildPlaybackOrigin(req.headers),
+          playPath,
+          name: movie.title,
+          runtimeTicks,
+          playbackClient,
+        })
+      : [defaultPlaybackMediaSource(id, movie.title, playUrl, runtimeTicks)]
     app.log.info(`playback: "${movie.title}" → ${playUrl}`)
     opts.registerPlaybackItem?.(id, playPath)
     opts.registerPlaybackClient?.(playPath, playbackClient)

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -16,7 +16,7 @@ import {
 import type { Movie, Show, Season, Episode } from '../db.js'
 import { buildPlaybackOrigin, createSignedPlaybackUrl } from '../play-auth.js'
 import { mdblistListPathFromUrl } from '../mdblist.js'
-import { searchStremioMetas, type StremioMediaType, type StremioMeta } from '../sootio.js'
+import { fetchStremioMeta, searchStremioMetas, type StremioMediaType, type StremioMeta } from '../sootio.js'
 
 // ── ID helpers ────────────────────────────────────────────────────────────────
 // Real Jellyfin uses GUIDs for all IDs. Infuse validates this client-side.
@@ -64,6 +64,15 @@ type JellyfinRouteOptions = {
   registerPlaybackClient?: (playPath: string, clientName: string) => void
   touchPlaybackItem?: (itemId: string) => void
   stopPlaybackItem?: (itemId: string) => void
+  buildPlaybackMediaSources?: (input: {
+    itemId: string
+    sourceId: string
+    origin: string
+    playPath: string
+    name: string
+    runtimeTicks: number
+    playbackClient: string
+  }) => Promise<Array<Record<string, unknown>>>
 }
 type ImageKind = 'poster' | 'backdrop' | 'logo'
 type ImageQuery = {
@@ -139,6 +148,21 @@ function stremioSearchMetaIds(meta: StremioMeta, mediaType: StremioMediaType): {
 
 function stremioSearchMetaToId(meta: StremioMeta, mediaType: StremioMediaType): string {
   return stremioSearchMetaIds(meta, mediaType).itemId
+}
+
+async function hydrateStremioSeriesMeta(series: StremioMeta): Promise<StremioMeta> {
+  if ((series.videos?.length ?? 0) > 0) return series
+  const detailed = await fetchStremioMeta('series', series.id).catch(() => null)
+  if (!detailed || !(detailed.videos?.length ?? 0)) return series
+
+  const merged: StremioMeta = {
+    ...series,
+    ...detailed,
+    type: detailed.type ?? series.type ?? 'series',
+    videos: detailed.videos,
+  }
+  stremioSearchMetaIds(merged, 'series')
+  return merged
 }
 
 function idToStremioSearchMeta(id: string): { meta: StremioMeta; mediaType: StremioMediaType; itemId: string; sourceId: string; requestedId: string } | null {
@@ -769,6 +793,7 @@ function movieToItem(m: Movie, userId = DEFAULT_ADMIN_USER_ID) {
     RunTimeTicks:       runtimeTicks,
     IsFolder:           false,
     Path:               fakePath,
+    EnableMediaSourceDisplay: true,
     ImageTags:          {
       ...(posterTag ? { Primary: posterTag } : {}),
       ...(logoTag ? { Logo: logoTag } : {}),
@@ -777,23 +802,6 @@ function movieToItem(m: Movie, userId = DEFAULT_ADMIN_USER_ID) {
     PrimaryImageTag:    null,
     BackdropImageTags:  m.backdropPath ? [m.backdropPath.replace(/\W/g, '').slice(0, 16)] : [],
     ParentId:           FOLDER_ID,
-    MediaSources: [{
-      Protocol:             'File',
-      Id:                   id,
-      Type:                 'Default',
-      Container:            'mkv',
-      Size:                 0,
-      Name:                 m.title,
-      Path:                 fakePath,
-      IsRemote:             false,
-      RunTimeTicks:         runtimeTicks,
-      SupportsTranscoding:  false,
-      SupportsDirectStream: true,
-      SupportsDirectPlay:   true,
-      IsInfiniteStream:     false,
-      RequiresOpening:      false,
-      RequiresClosing:      false,
-    }],
     ProviderIds:        { Imdb: m.imdbId || undefined, Tmdb: String(m.tmdbId) },
     UserData:           userDataForItem(id, ud, runtimeTicks),
   }
@@ -873,6 +881,53 @@ function stremioRuntimeTicks(meta: StremioMeta, fallbackMins: number): number {
   return totalMins * 60 * 10_000_000
 }
 
+function stremioSeriesTmdbId(series: StremioMeta): number | null {
+  const id = series.id.startsWith('tmdb:') ? Number.parseInt(series.id.slice(5), 10) : NaN
+  return Number.isFinite(id) && id > 0 ? id : null
+}
+
+function stremioEpisodeAirDate(ep: StremioMeta): string {
+  const released = typeof ep.released === 'string' ? ep.released.slice(0, 10) : ''
+  if (/^\d{4}-\d{2}-\d{2}$/.test(released)) return released
+
+  const releaseInfo = String(ep.releaseInfo ?? '')
+  const dateMatch = releaseInfo.match(/\b(19\d{2}|20\d{2})-\d{2}-\d{2}\b/)
+  return dateMatch?.[0] ?? ''
+}
+
+function isStremioEpisodeVisibleToLibrary(ep: StremioMeta): boolean {
+  return isEpisodeVisibleToLibrary({ airDate: stremioEpisodeAirDate(ep) })
+}
+
+function visibleStremioEpisodesFromMeta(series: StremioMeta): StremioMeta[] {
+  return (series.videos ?? []).filter(isStremioEpisodeVisibleToLibrary)
+}
+
+async function visibleStremioEpisodes(series: StremioMeta): Promise<StremioMeta[]> {
+  const episodes = series.videos ?? []
+  const tmdbId = stremioSeriesTmdbId(series)
+  if (!tmdbId) return episodes.filter(isStremioEpisodeVisibleToLibrary)
+
+  const seasonNumbers = stremioSeriesSeasons(episodes)
+  await Promise.all(seasonNumbers.map(async seasonNumber => {
+    if (getEpisodesForSeason(tmdbId, seasonNumber).length) return
+    await fetchAndCacheSeasonDetails(tmdbId, seasonNumber).catch(() => [])
+  }))
+
+  const cachedEpisodes = new Map<string, Episode>()
+  for (const seasonNumber of seasonNumbers) {
+    for (const episode of getEpisodesForSeason(tmdbId, seasonNumber)) {
+      cachedEpisodes.set(`${episode.seasonNumber}:${episode.episodeNumber}`, episode)
+    }
+  }
+
+  return episodes.filter(ep => {
+    const cached = cachedEpisodes.get(`${stremioEpisodeSeasonNumber(ep)}:${stremioEpisodeNumber(ep)}`)
+    if (cached) return isEpisodeVisibleToLibrary(cached)
+    return isStremioEpisodeVisibleToLibrary(ep)
+  })
+}
+
 function stremioMetaExternalUrls(meta: StremioMeta, mediaType: StremioMediaType) {
   const urls = []
   const imdbId = meta.imdb_id || meta.imdbId || (meta.id.startsWith('tt') ? meta.id : '')
@@ -899,7 +954,24 @@ function stremioSearchTypeLabel(includeTypes: string): string {
   return labels.length ? labels.join(',') : includeTypes
 }
 
-function stremioSearchMetaToItem(meta: StremioMeta, mediaType: StremioMediaType, requestedId?: string) {
+function searchMovieAutoplayItem(item: Record<string, unknown>): Record<string, unknown> {
+  if (item.Type !== 'Movie') return item
+  const copy = { ...item }
+  copy.PlayAccess = 'Full'
+  copy.IsPlayable = true
+  copy.CanDownload = true
+  delete copy.MediaSources
+  delete copy.AlternateMediaSources
+  delete copy.MediaSourceCount
+  return copy
+}
+
+function stremioSearchMetaToItem(
+  meta: StremioMeta,
+  mediaType: StremioMediaType,
+  requestedId?: string,
+  options: { suppressMovieAutoplay?: boolean } = {},
+) {
   const { itemId, sourceId } = stremioSearchMetaIds(meta, mediaType)
   const id = requestedId ?? itemId
   const name = stremioMetaName(meta)
@@ -909,6 +981,7 @@ function stremioSearchMetaToItem(meta: StremioMeta, mediaType: StremioMediaType,
   const primaryTag = meta.poster ? createHash('md5').update(meta.poster).digest('hex') : undefined
   const logoTag = meta.logo ? createHash('sha1').update(meta.logo).digest('hex').slice(0, 16) : undefined
   const isMovie = mediaType === 'movie'
+  const visibleEpisodeCount = isMovie ? undefined : visibleStremioEpisodesFromMeta(meta).length
   const year = stremioMetaYear(meta)
   const date = meta.released ? `${meta.released.slice(0, 10)}T00:00:00.0000000Z` : year ? `${year}-01-01T00:00:00.0000000Z` : undefined
   return {
@@ -920,10 +993,10 @@ function stremioSearchMetaToItem(meta: StremioMeta, mediaType: StremioMediaType,
     MediaType:          isMovie ? 'Video' : undefined,
     VideoType:          isMovie ? 'VideoFile' : undefined,
     LocationType:       'Remote',
-    PlayAccess:         'Full',
-    IsPlayable:         isMovie,
+    PlayAccess:         isMovie && options.suppressMovieAutoplay ? 'None' : 'Full',
+    IsPlayable:         isMovie && !options.suppressMovieAutoplay,
     CanDelete:          false,
-    CanDownload:        isMovie,
+    CanDownload:        isMovie && !options.suppressMovieAutoplay,
     ChannelId:          null,
     ProductionYear:     year,
     Overview:           meta.overview || meta.description,
@@ -941,8 +1014,8 @@ function stremioSearchMetaToItem(meta: StremioMeta, mediaType: StremioMediaType,
     IsFolder:           !isMovie,
     Path:               path,
     EnableMediaSourceDisplay: isMovie ? true : undefined,
-    ChildCount:         isMovie ? undefined : (meta.videos?.length ?? 0),
-    RecursiveItemCount: isMovie ? undefined : (meta.videos?.length ?? 0),
+    ChildCount:         visibleEpisodeCount,
+    RecursiveItemCount: visibleEpisodeCount,
     ImageTags:          {
       ...(primaryTag ? { Primary: primaryTag } : {}),
       ...(logoTag ? { Logo: logoTag } : {}),
@@ -955,26 +1028,6 @@ function stremioSearchMetaToItem(meta: StremioMeta, mediaType: StremioMediaType,
       Stremio: meta.id,
     },
     UserData:           userDataForItem(id, { played: false, playCount: 0, positionTicks: 0, lastPlayedDate: '' }, runtimeTicks),
-    MediaSources:       isMovie ? [{
-      Protocol:             'Http',
-      Id:                   sourceId,
-      Type:                 'Default',
-      Container:            'mkv',
-      Size:                 0,
-      Name:                 name,
-      Path:                 path,
-      IsRemote:             false,
-      RunTimeTicks:         runtimeTicks,
-      SupportsTranscoding:  true,
-      SupportsDirectStream: true,
-      SupportsDirectPlay:   true,
-      SupportsProbing:      true,
-      HasSegments:          false,
-      VideoType:            'VideoFile',
-      IsInfiniteStream:     false,
-      RequiresOpening:      false,
-      RequiresClosing:      false,
-    }] : undefined,
   }
 }
 
@@ -993,7 +1046,8 @@ function stremioSeriesSeasons(series: StremioMeta[]) {
 function stremioSeasonToItem(series: StremioMeta, seasonNumber: number) {
   const id = stremioSeasonToId(series, seasonNumber)
   const seriesId = stremioSearchMetaToId(series, 'series')
-  const episodes = (series.videos ?? []).filter(ep => stremioEpisodeSeasonNumber(ep) === seasonNumber)
+  const episodes = visibleStremioEpisodesFromMeta(series)
+    .filter(ep => stremioEpisodeSeasonNumber(ep) === seasonNumber)
   return {
     Id:             id,
     ServerId:       SERVER_GUID,
@@ -1048,26 +1102,6 @@ function stremioEpisodeToItem(series: StremioMeta, episode: StremioMeta) {
     ImageTags:          (episode.poster || series.poster) ? { Primary: createHash('sha1').update(episode.poster || series.poster || '').digest('hex').slice(0, 16) } : {},
     ProviderIds:        { Stremio: episode.id || `${series.id}:${seasonNumber}:${episodeNumber}` },
     UserData:           userDataForItem(id, { played: false, playCount: 0, positionTicks: 0, lastPlayedDate: '' }, runtimeTicks),
-    MediaSources: [{
-      Protocol:             'Http',
-      Id:                   id,
-      Type:                 'Default',
-      Container:            'mkv',
-      Size:                 0,
-      Name:                 name,
-      Path:                 path,
-      IsRemote:             false,
-      RunTimeTicks:         runtimeTicks,
-      SupportsTranscoding:  true,
-      SupportsDirectStream: true,
-      SupportsDirectPlay:   true,
-      SupportsProbing:      true,
-      HasSegments:          false,
-      VideoType:            'VideoFile',
-      IsInfiniteStream:     false,
-      RequiresOpening:      false,
-      RequiresClosing:      false,
-    }],
   }
 }
 
@@ -1294,7 +1328,7 @@ async function buildSearchResultItems(
   const localShowIds = new Set(localShows.map(show => show.tmdbId))
   const localMovieImdbIds = new Set(localMovies.map(movie => movie.imdbId).filter(Boolean))
   const localShowImdbIds = new Set(localShows.map(show => show.imdbId).filter(Boolean))
-  const stremioSearchItems = stremioMetas
+  const stremioSearchMetas = stremioMetas
     .filter(meta => {
       const mediaType = String(meta.type ?? '').toLowerCase() as StremioMediaType
       if (mediaType !== 'movie' && mediaType !== 'series') return false
@@ -1309,10 +1343,15 @@ async function buildSearchResultItems(
       }
       return true
     })
-    .map(meta => stremioSearchMetaToItem(meta, String(meta.type ?? 'movie').toLowerCase() === 'series' ? 'series' : 'movie'))
+  const stremioSearchItems = await Promise.all(stremioSearchMetas.map(async meta => {
+    const mediaType = String(meta.type ?? 'movie').toLowerCase() === 'series' ? 'series' : 'movie'
+    const hydrated = mediaType === 'series' ? await hydrateStremioSeriesMeta(meta) : meta
+    const item = stremioSearchMetaToItem(hydrated, mediaType) as Record<string, unknown>
+    return mediaType === 'movie' ? searchMovieAutoplayItem(item) : item
+  }))
 
   const combined = [
-    ...localMovies.map(movie => movieToItem(movie, user.id)),
+    ...localMovies.map(movie => searchMovieAutoplayItem(movieToSearchItem(movie) as Record<string, unknown>)),
     ...localShows.map(show => showToSeriesItem(show, user.id)),
     ...stremioSearchItems,
   ]
@@ -1451,23 +1490,6 @@ function episodeToItem(ep: Episode, show: Show, userId = DEFAULT_ADMIN_USER_ID) 
     ParentBackdropImageTags: showBackdropTag ? [showBackdropTag] : [],
     ParentLogoItemId:      showLogoTag ? seriesId : undefined,
     ParentLogoImageTag:    showLogoTag,
-    MediaSources: [{
-      Protocol:             'File',
-      Id:                   id,
-      Type:                 'Default',
-      Container:            'mkv',
-      Size:                 0,
-      Name:                 ep.name || `S${ep.seasonNumber}E${ep.episodeNumber}`,
-      Path:                 fakePath,
-      IsRemote:             false,
-      RunTimeTicks:         runtimeTicks,
-      SupportsTranscoding:  false,
-      SupportsDirectStream: true,
-      SupportsDirectPlay:   true,
-      IsInfiniteStream:     false,
-      RequiresOpening:      false,
-      RequiresClosing:      false,
-    }],
     UserData:              userDataForItem(id, ud, runtimeTicks),
   }
 }
@@ -1585,6 +1607,64 @@ function jellyfinSessionInfo(user: AppUser, accessToken: string) {
 function queryValue(value: string | string[] | undefined): string {
   if (Array.isArray(value)) return value[0] ?? ''
   return value ?? ''
+}
+
+function defaultPlaybackMediaSource(id: string, name: string, playUrl: string, runtimeTicks: number) {
+  return {
+    Id:                   id,
+    Name:                 name,
+    Type:                 'Default',
+    Protocol:             'Http',
+    Path:                 playUrl,
+    IsRemote:             true,
+    SupportsDirectPlay:   true,
+    SupportsDirectStream: true,
+    SupportsTranscoding:  false,
+    RequiresOpening:      false,
+    RequiresClosing:      false,
+    Container:            'mkv',
+    RunTimeTicks:         runtimeTicks,
+    MediaStreams: [
+      { Type: 'Video', Index: 0, Codec: 'h264', IsDefault: true },
+      { Type: 'Audio', Index: 1, Codec: 'aac',  IsDefault: true, Language: 'eng' },
+    ],
+  }
+}
+
+async function playbackMediaSourcesFor(
+  opts: JellyfinRouteOptions,
+  input: {
+    itemId: string
+    sourceId: string
+    origin: string
+    playPath: string
+    name: string
+    runtimeTicks: number
+    playbackClient: string
+  },
+) {
+  if (opts.buildPlaybackMediaSources) {
+    const sources = await opts.buildPlaybackMediaSources(input).catch(() => [])
+    if (sources.length) return sources
+  }
+  return [defaultPlaybackMediaSource(
+    input.sourceId,
+    input.name,
+    createSignedPlaybackUrl(input.origin, input.playPath),
+    input.runtimeTicks,
+  )]
+}
+
+function candidateTokenFromMediaSourceId(mediaSourceId: string | undefined): string | null {
+  const match = mediaSourceId?.match(/:candidate:([0-9a-f]{32})$/i)
+  return match?.[1] ?? null
+}
+
+function signedPlaybackUrlForMediaSource(origin: string, playPath: string, mediaSourceId: string | undefined): string {
+  const url = new URL(createSignedPlaybackUrl(origin, playPath))
+  const candidate = candidateTokenFromMediaSourceId(mediaSourceId)
+  if (candidate) url.searchParams.set('candidate', candidate)
+  return url.toString()
 }
 
 // ── Route registration ────────────────────────────────────────────────────────
@@ -1855,17 +1935,18 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const stremioSeries = ParentId ? idToStremioSearchMeta(ParentId) : null
     if (stremioSeries?.mediaType === 'series') {
+      const seriesMeta = await hydrateStremioSeriesMeta(stremioSeries.meta)
+      const visibleEpisodes = await visibleStremioEpisodes(seriesMeta)
       if (includeTypes.includes('episode')) {
-        const episodes = stremioSeries.meta.videos ?? []
         return {
-          Items: pagedItems(episodes, offset, limit).map(ep => stremioEpisodeToItem(stremioSeries.meta, ep)),
-          TotalRecordCount: episodes.length,
+          Items: pagedItems(visibleEpisodes, offset, limit).map(ep => stremioEpisodeToItem(seriesMeta, ep)),
+          TotalRecordCount: visibleEpisodes.length,
           StartIndex: offset,
         }
       }
-      const seasonNumbers = stremioSeriesSeasons(stremioSeries.meta.videos ?? [])
+      const seasonNumbers = stremioSeriesSeasons(visibleEpisodes)
       return {
-        Items: seasonNumbers.map(seasonNumber => stremioSeasonToItem(stremioSeries.meta, seasonNumber)),
+        Items: seasonNumbers.map(seasonNumber => stremioSeasonToItem(seriesMeta, seasonNumber)),
         TotalRecordCount: seasonNumbers.length,
         StartIndex: offset,
       }
@@ -1873,7 +1954,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const stremioSeasonRef = ParentId ? idToStremioSeason(ParentId) : null
     if (stremioSeasonRef) {
-      const episodes = (stremioSeasonRef.series.videos ?? [])
+      const episodes = (await visibleStremioEpisodes(stremioSeasonRef.series))
         .filter(ep => stremioEpisodeSeasonNumber(ep) === stremioSeasonRef.seasonNumber)
       return {
         Items: pagedItems(episodes, offset, limit).map(ep => stremioEpisodeToItem(stremioSeasonRef.series, ep)),
@@ -2150,7 +2231,40 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
   })
 
   // Single item — /Items/:id and /Users/:userId/Items/:itemId
-  async function handleItem(id: string, reply: { code: (n: number) => { send: (v: unknown) => unknown } }, user?: AppUser | null) {
+  async function addDetailMediaSources(
+    item: Record<string, unknown>,
+    headers: Record<string, string | string[] | undefined> | undefined,
+    input: {
+      itemId: string
+      sourceId: string
+      playPath: string
+      name: string
+      runtimeTicks: number
+    },
+  ) {
+    if (!headers) return item
+    const normalizedHeaders = Object.fromEntries(
+      Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value[0] ?? '' : value ?? '']),
+    )
+    const mediaSources = await playbackMediaSourcesFor(opts, {
+      ...input,
+      origin: buildPlaybackOrigin(normalizedHeaders),
+      playbackClient: playbackClientFromHeaders(headers),
+    })
+    return {
+      ...item,
+      MediaSources: mediaSources,
+      AlternateMediaSources: mediaSources,
+      MediaSourceCount: mediaSources.length,
+    }
+  }
+
+  async function handleItem(
+    id: string,
+    reply: { code: (n: number) => { send: (v: unknown) => unknown } },
+    user?: AppUser | null,
+    headers?: Record<string, string | string[] | undefined>,
+  ) {
     const currentUser = user === undefined ? fallbackUser() : user
     if (!currentUser) return reply.code(401).send({ error: 'Unauthorized' })
     // Collection folders
@@ -2186,13 +2300,34 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     }
 
     const stremioEpisode = idToStremioEpisode(id)
-    if (stremioEpisode) return stremioEpisodeToItem(stremioEpisode.series, stremioEpisode.episode)
+    if (stremioEpisode) {
+      const item = stremioEpisodeToItem(stremioEpisode.series, stremioEpisode.episode) as Record<string, unknown>
+      if (!config.mediaSourceSelection) return item
+      const { series, episode } = stremioEpisode
+      const externalId = episode.id || `${series.id}:${stremioEpisodeSeasonNumber(episode)}:${stremioEpisodeNumber(episode)}`
+      const playPath = `/play/stremio/series/${encodeURIComponent(externalId)}`
+      const name = `${stremioMetaName(series)} - ${stremioMetaName(episode)}`
+      return addDetailMediaSources(item, headers, {
+        itemId: id,
+        sourceId: id,
+        playPath,
+        name,
+        runtimeTicks: stremioRuntimeTicks(episode, 45),
+      })
+    }
 
     const stremioSeason = idToStremioSeason(id)
     if (stremioSeason) return stremioSeasonToItem(stremioSeason.series, stremioSeason.seasonNumber)
 
     const stremioSearch = idToStremioSearchMeta(id)
-    if (stremioSearch) return stremioSearchMetaToItem(stremioSearch.meta, stremioSearch.mediaType, stremioSearch.requestedId)
+    if (stremioSearch) {
+      const meta = stremioSearch.mediaType === 'series'
+        ? await hydrateStremioSeriesMeta(stremioSearch.meta)
+        : stremioSearch.meta
+      const item = stremioSearchMetaToItem(meta, stremioSearch.mediaType, stremioSearch.requestedId) as Record<string, unknown>
+      if (stremioSearch.mediaType !== 'movie') return item
+      return searchMovieAutoplayItem(item)
+    }
 
     // Episode
     const epRef = idToEpisode(id)
@@ -2209,7 +2344,16 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       }
       if (!ep) return reply.code(404).send({ error: 'Not found' })
       if (!isEpisodeVisibleToLibrary(ep)) return reply.code(404).send({ error: 'Not found' })
-      return episodeToItem(ep, show, currentUser.id)
+      const item = episodeToItem(ep, show, currentUser.id) as Record<string, unknown>
+      if (!config.mediaSourceSelection || !show.imdbId) return item
+      const playPath = `/play/${show.imdbId}/${ep.seasonNumber}/${ep.episodeNumber}`
+      return addDetailMediaSources(item, headers, {
+        itemId: id,
+        sourceId: id,
+        playPath,
+        name: `${show.title} - ${ep.name || `S${ep.seasonNumber}E${ep.episodeNumber}`}`,
+        runtimeTicks: (ep.runtimeMins || 45) * 60 * 10_000_000,
+      })
     }
 
     // Season
@@ -2252,7 +2396,8 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const movie = await fetchMovieByTmdbId(searchMovieTmdbId)
       if (!movie) return reply.code(404).send({ error: 'Not found' })
       if (!canUserAccessMovie(currentUser, movie)) return reply.code(404).send({ error: 'Not found' })
-      return movieToSearchItem(movie)
+      const item = movieToSearchItem(movie) as Record<string, unknown>
+      return searchMovieAutoplayItem(item)
     }
 
     const tmdbId = idToTmdb(id)
@@ -2267,12 +2412,12 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
   app.get('/Items/:id', async (req, reply) => {
     const user = requireRequestUser(req.headers, reply as never)
     if (!user) return
-    return handleItem((req.params as { id: string }).id, reply as never, user)
+    return handleItem((req.params as { id: string }).id, reply as never, user, req.headers)
   })
   app.get('/Users/:userId/Items/:itemId', async (req, reply) => {
     const user = requireRequestUser(req.headers, reply as never)
     if (!user) return
-    return handleItem((req.params as { itemId: string }).itemId, reply as never, user)
+    return handleItem((req.params as { itemId: string }).itemId, reply as never, user, req.headers)
   })
 
   // Seasons list for a series — Infuse calls this when opening a show
@@ -2282,9 +2427,11 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const { seriesId } = req.params as { seriesId: string }
     const stremioSeries = idToStremioSearchMeta(seriesId)
     if (stremioSeries?.mediaType === 'series') {
-      const seasonNumbers = stremioSeriesSeasons(stremioSeries.meta.videos ?? [])
+      const seriesMeta = await hydrateStremioSeriesMeta(stremioSeries.meta)
+      const visibleEpisodes = await visibleStremioEpisodes(seriesMeta)
+      const seasonNumbers = stremioSeriesSeasons(visibleEpisodes)
       return {
-        Items: seasonNumbers.map(seasonNumber => stremioSeasonToItem(stremioSeries.meta, seasonNumber)),
+        Items: seasonNumbers.map(seasonNumber => stremioSeasonToItem(seriesMeta, seasonNumber)),
         TotalRecordCount: seasonNumbers.length,
         StartIndex: 0,
       }
@@ -2315,12 +2462,14 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const SeasonId = q.seasonid
     const stremioSeries = idToStremioSearchMeta(seriesId)
     if (stremioSeries?.mediaType === 'series') {
+      const seriesMeta = await hydrateStremioSeriesMeta(stremioSeries.meta)
       const stremioSeason = SeasonId ? idToStremioSeason(SeasonId) : null
+      const visibleEpisodes = await visibleStremioEpisodes(seriesMeta)
       const episodes = stremioSeason
-        ? (stremioSeries.meta.videos ?? []).filter(ep => stremioEpisodeSeasonNumber(ep) === stremioSeason.seasonNumber)
-        : (stremioSeries.meta.videos ?? [])
+        ? visibleEpisodes.filter(ep => stremioEpisodeSeasonNumber(ep) === stremioSeason.seasonNumber)
+        : visibleEpisodes
       return {
-        Items: episodes.map(ep => stremioEpisodeToItem(stremioSeries.meta, ep)),
+        Items: episodes.map(ep => stremioEpisodeToItem(seriesMeta, ep)),
         TotalRecordCount: episodes.length,
         StartIndex: 0,
       }
@@ -2630,30 +2779,25 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
       const name = `${stremioMetaName(series)} - ${stremioMetaName(episode)}`
       const runtimeTicks = stremioRuntimeTicks(episode, 45)
+      const playbackClient = playbackClientFromHeaders(req.headers)
+      const mediaSources = config.mediaSourceSelection
+        ? await playbackMediaSourcesFor(opts, {
+            itemId: id,
+            sourceId: id,
+            origin: buildPlaybackOrigin(req.headers),
+            playPath,
+            name,
+            runtimeTicks,
+            playbackClient,
+          })
+        : [defaultPlaybackMediaSource(id, name, playUrl, runtimeTicks)]
       app.log.info(`playback: Stremio "${name}" → ${playUrl}`)
       opts.registerPlaybackItem?.(id, playPath)
-      opts.registerPlaybackClient?.(playPath, playbackClientFromHeaders(req.headers))
+      opts.registerPlaybackClient?.(playPath, playbackClient)
       opts.prewarmPlayback?.(playPath, name)
       return {
-        MediaSources: [{
-          Id:                   id,
-          Name:                 name,
-          Type:                 'Default',
-          Protocol:             'Http',
-          Path:                 playUrl,
-          IsRemote:             true,
-          SupportsDirectPlay:   true,
-          SupportsDirectStream: true,
-          SupportsTranscoding:  false,
-          RequiresOpening:      false,
-          RequiresClosing:      false,
-          Container:            'mkv',
-          RunTimeTicks:         runtimeTicks,
-          MediaStreams: [
-            { Type: 'Video', Index: 0, Codec: 'h264', IsDefault: true },
-            { Type: 'Audio', Index: 1, Codec: 'aac',  IsDefault: true, Language: 'eng' },
-          ],
-        }],
+        MediaSources: mediaSources,
+        AlternateMediaSources: mediaSources,
         PlaySessionId: `fetcherr-${id}`,
       }
     }
@@ -2663,34 +2807,19 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const { meta, mediaType, sourceId } = stremioSearch
       if (mediaType !== 'movie') return reply.code(404).send({ error: 'Not playable' })
       const externalId = meta.imdb_id || meta.imdbId || meta.id
-      const playPath = `/play/stremio/${mediaType}/${encodeURIComponent(externalId)}`
+      const playPath = `/play/stremio/movie/${encodeURIComponent(externalId)}`
       const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
       const name = stremioMetaName(meta)
       const runtimeTicks = stremioRuntimeTicks(meta, 90)
+      const playbackClient = playbackClientFromHeaders(req.headers)
+      const mediaSources = [defaultPlaybackMediaSource(sourceId, name, playUrl, runtimeTicks)]
       app.log.info(`playback: Stremio "${name}" → ${playUrl}`)
       opts.registerPlaybackItem?.(id, playPath)
-      opts.registerPlaybackClient?.(playPath, playbackClientFromHeaders(req.headers))
+      opts.registerPlaybackClient?.(playPath, playbackClient)
       opts.prewarmPlayback?.(playPath, name)
       return {
-        MediaSources: [{
-          Id:                   sourceId,
-          Name:                 name,
-          Type:                 'Default',
-          Protocol:             'Http',
-          Path:                 playUrl,
-          IsRemote:             true,
-          SupportsDirectPlay:   true,
-          SupportsDirectStream: true,
-          SupportsTranscoding:  false,
-          RequiresOpening:      false,
-          RequiresClosing:      false,
-          Container:            'mkv',
-          RunTimeTicks:         runtimeTicks,
-          MediaStreams: [
-            { Type: 'Video', Index: 0, Codec: 'h264', IsDefault: true },
-            { Type: 'Audio', Index: 1, Codec: 'aac',  IsDefault: true, Language: 'eng' },
-          ],
-        }],
+        MediaSources: mediaSources,
+        AlternateMediaSources: mediaSources,
         PlaySessionId: `fetcherr-${id}`,
       }
     }
@@ -2714,35 +2843,56 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const playPath = `/play/${show.imdbId}/${epRef.seasonNum}/${epRef.episodeNum}`
       const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
       const label = ep ? ep.name : `S${epRef.seasonNum}E${epRef.episodeNum}`
+      const name = `${show.title} - ${label}`
+      const runtimeTicks = (ep?.runtimeMins || 45) * 60 * 10_000_000
+      const playbackClient = playbackClientFromHeaders(req.headers)
+      const mediaSources = config.mediaSourceSelection
+        ? await playbackMediaSourcesFor(opts, {
+            itemId: id,
+            sourceId: id,
+            origin: buildPlaybackOrigin(req.headers),
+            playPath,
+            name,
+            runtimeTicks,
+            playbackClient,
+          })
+        : [defaultPlaybackMediaSource(id, name, playUrl, runtimeTicks)]
       app.log.info(`playback: "${show.title}" ${label} → ${playUrl}`)
       opts.registerPlaybackItem?.(id, playPath)
-      opts.registerPlaybackClient?.(playPath, playbackClientFromHeaders(req.headers))
+      opts.registerPlaybackClient?.(playPath, playbackClient)
       opts.prewarmPlayback?.(playPath, `${show.title} ${label}`)
       return {
-        MediaSources: [{
-          Id:                   id,
-          Name:                 `${show.title} - ${label}`,
-          Type:                 'Default',
-          Protocol:             'Http',
-          Path:                 playUrl,
-          IsRemote:             true,
-          SupportsDirectPlay:   true,
-          SupportsDirectStream: true,
-          SupportsTranscoding:  false,
-          RequiresOpening:      false,
-          RequiresClosing:      false,
-          Container:            'mkv',
-          RunTimeTicks:         (ep?.runtimeMins || 45) * 60 * 10_000_000,
-          MediaStreams: [
-            { Type: 'Video', Index: 0, Codec: 'h264', IsDefault: true },
-            { Type: 'Audio', Index: 1, Codec: 'aac',  IsDefault: true, Language: 'eng' },
-          ],
-        }],
+        MediaSources: mediaSources,
+        AlternateMediaSources: mediaSources,
         PlaySessionId: `fetcherr-${id}`,
       }
     }
 
     // Movie playback
+    const searchMovieTmdbId = idToSearchMovieTmdb(id)
+    if (searchMovieTmdbId) {
+      const movie = await fetchMovieByTmdbId(searchMovieTmdbId)
+      if (!movie?.imdbId) return reply.code(404).send({ error: 'No IMDb ID for this title' })
+      if (!canUserAccessMovie(user, movie)) return reply.code(404).send({ error: 'Not found' })
+      if (!isMovieVisibleToLibrary(movie)) {
+        return reply.code(409).send({ error: 'Title not yet available', message: 'Not Yet Released' })
+      }
+      const playPath = `/play/${movie.imdbId}`
+      const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
+      const runtimeTicks = (movie.runtimeMins || 90) * 60 * 10_000_000
+      const playbackClient = playbackClientFromHeaders(req.headers)
+      const mediaSources = [defaultPlaybackMediaSource(id, movie.title, playUrl, runtimeTicks)]
+      app.log.info(`playback: "${movie.title}" → ${playUrl}`)
+      opts.registerPlaybackItem?.(id, playPath)
+      opts.registerPlaybackClient?.(playPath, playbackClient)
+      opts.prewarmPlayback?.(playPath, movie.title)
+      return {
+        MediaSources: mediaSources,
+        AlternateMediaSources: mediaSources,
+        PlaySessionId: `fetcherr-${id}`,
+      }
+    }
+
     const tmdbId = idToTmdb(id)
     if (!tmdbId) return reply.code(404).send({ error: 'Not found' })
     const movie = getMovieByTmdbId(tmdbId) ?? await fetchMovieByTmdbId(tmdbId)
@@ -2754,30 +2904,16 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const playPath = `/play/${movie.imdbId}`
     const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
+    const runtimeTicks = (movie.runtimeMins || 90) * 60 * 10_000_000
+    const playbackClient = playbackClientFromHeaders(req.headers)
+    const mediaSources = [defaultPlaybackMediaSource(id, movie.title, playUrl, runtimeTicks)]
     app.log.info(`playback: "${movie.title}" → ${playUrl}`)
     opts.registerPlaybackItem?.(id, playPath)
-    opts.registerPlaybackClient?.(playPath, playbackClientFromHeaders(req.headers))
+    opts.registerPlaybackClient?.(playPath, playbackClient)
     opts.prewarmPlayback?.(playPath, movie.title)
     return {
-      MediaSources: [{
-        Id:                   id,
-        Name:                 movie.title,
-        Type:                 'Default',
-        Protocol:             'Http',
-        Path:                 playUrl,
-        IsRemote:             true,
-        SupportsDirectPlay:   true,
-        SupportsDirectStream: true,
-        SupportsTranscoding:  false,
-        RequiresOpening:      false,
-        RequiresClosing:      false,
-        Container:            'mkv',
-        RunTimeTicks:         (movie.runtimeMins || 90) * 60 * 10_000_000,
-        MediaStreams: [
-          { Type: 'Video', Index: 0, Codec: 'h264', IsDefault: true },
-          { Type: 'Audio', Index: 1, Codec: 'aac',  IsDefault: true, Language: 'eng' },
-        ],
-      }],
+      MediaSources: mediaSources,
+      AlternateMediaSources: mediaSources,
       PlaySessionId: `fetcherr-${id}`,
     }
   }
@@ -2788,9 +2924,13 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
   // Video stream redirect (fallback for some Infuse/VidHub versions)
   app.get('/Videos/:id/stream', async (req, reply) => {
     const { id } = req.params as { id: string }
-    const query = req.query as { playSessionId?: string; mediaSourceId?: string } | undefined
-    const sessionMatches = query?.playSessionId === `fetcherr-${id}`
-    const sourceMatches = query?.mediaSourceId === id
+    const query = req.query as { playSessionId?: string; PlaySessionId?: string; mediaSourceId?: string; MediaSourceId?: string } | undefined
+    const playSessionId = query?.playSessionId ?? query?.PlaySessionId
+    const mediaSourceId = query?.mediaSourceId ?? query?.MediaSourceId
+    const sessionMatches = playSessionId === `fetcherr-${id}`
+    const sourceMatches = mediaSourceId === id
+      || Boolean(candidateTokenFromMediaSourceId(mediaSourceId))
+      || idToStremioSearchMeta(id)?.sourceId === mediaSourceId
     const user = requestUser(req.headers) ?? ((sessionMatches || sourceMatches) ? fallbackUser() : null)
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
 
@@ -2801,7 +2941,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const { series, episode } = stremioEpisode
       const externalId = episode.id || `${series.id}:${stremioEpisodeSeasonNumber(episode)}:${stremioEpisodeNumber(episode)}`
       const playPath = `/play/stremio/series/${encodeURIComponent(externalId)}`
-      return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
+      return reply.redirect(signedPlaybackUrlForMediaSource(origin, playPath, mediaSourceId), 302)
     }
 
     const stremioSearch = idToStremioSearchMeta(id)
@@ -2809,7 +2949,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const { meta, mediaType } = stremioSearch
       if (mediaType !== 'movie') return reply.code(404).send()
       const externalId = meta.imdb_id || meta.imdbId || meta.id
-      const playPath = `/play/stremio/${mediaType}/${encodeURIComponent(externalId)}`
+      const playPath = `/play/stremio/movie/${encodeURIComponent(externalId)}`
       return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
     }
 
@@ -2820,6 +2960,16 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       if (!show?.imdbId) return reply.code(404).send()
       if (!canUserAccessShow(user, show)) return reply.code(404).send()
       const playPath = `/play/${show.imdbId}/${epRef.seasonNum}/${epRef.episodeNum}`
+      return reply.redirect(signedPlaybackUrlForMediaSource(origin, playPath, mediaSourceId), 302)
+    }
+
+    const searchMovieTmdbId = idToSearchMovieTmdb(id)
+    if (searchMovieTmdbId) {
+      const movie = await fetchMovieByTmdbId(searchMovieTmdbId)
+      if (!movie?.imdbId) return reply.code(404).send()
+      if (!canUserAccessMovie(user, movie)) return reply.code(404).send()
+      if (!isMovieVisibleToLibrary(movie)) return reply.code(409).send({ error: 'Title not yet available', message: 'Not Yet Released' })
+      const playPath = `/play/${movie.imdbId}`
       return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
     }
 
@@ -2829,6 +2979,6 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     if (!canUserAccessMovie(user, movie)) return reply.code(404).send()
     if (!isMovieVisibleToLibrary(movie)) return reply.code(409).send({ error: 'Title not yet available', message: 'Not Yet Released' })
     const playPath = `/play/${movie.imdbId}`
-    return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
+    return reply.redirect(signedPlaybackUrlForMediaSource(origin, playPath, mediaSourceId), 302)
   })
 }

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -8,11 +8,13 @@ import {
   listUsers, getUserData, saveProgress, markPlayed, markUnplayed, listResumeItemIds, countResumeItems, getAllPlayedItemIds,
   getEffectiveShowMode, listShows, countShows, getShowByTmdbId,
   getSeasonsForShow, getSeason, getEpisodesForSeason, getAiredEpisodesForSeason, isMovieVisibleToLibrary, isEpisodeVisibleToLibrary, hasAnySourceItem,
-  authEnabled, canUserAccessMovie, canUserAccessShow, getDb, getUserById, getUserByUsername, verifyUserCredentials, DEFAULT_ADMIN_USER_ID, isLibraryItemHidden, listSourceItems, type AppUser,
+  authEnabled, canUserAccessKnownRating, canUserAccessMovie, canUserAccessShow, getDb, getUserById, getUserByUsername, hasRatingLimit, verifyUserCredentials, DEFAULT_ADMIN_USER_ID, isLibraryItemHidden, listSourceItems, type AppUser,
 } from '../db.js'
 import {
   fetchMovieByTmdbId, posterUrl,
   fetchShowByTmdbId,
+  fetchMovieOfficialRatingByIds,
+  fetchShowOfficialRatingByIds,
   fetchAndCacheSeasonDetails, ensureShowSeasonsCached,
 } from '../tmdb.js'
 import type { Movie, Show, Season, Episode } from '../db.js'
@@ -66,6 +68,7 @@ const traktCollectionSummaryCache = new Map<string, { expiresAt: number; summari
 const stremioSearchCache = new Map<string, { meta: StremioMeta; mediaType: StremioMediaType; itemId: string; sourceId: string; expiresAt: number }>()
 const stremioSeasonCache = new Map<string, { series: StremioMeta; seasonNumber: number; expiresAt: number }>()
 const stremioEpisodeCache = new Map<string, { series: StremioMeta; episode: StremioMeta; expiresAt: number }>()
+const stremioRatingCache = new Map<string, { rating: string; expiresAt: number }>()
 type JellyfinRouteOptions = {
   prewarmPlayback?: (playPath: string, label: string) => void
   registerPlaybackItem?: (itemId: string, playPath: string) => void
@@ -260,6 +263,9 @@ function pruneStremioCaches(now = Date.now()): void {
   }
   for (const [id, entry] of stremioEpisodeCache) {
     if (entry.expiresAt <= now) stremioEpisodeCache.delete(id)
+  }
+  for (const [key, entry] of stremioRatingCache) {
+    if (entry.expiresAt <= now) stremioRatingCache.delete(key)
   }
 }
 
@@ -1173,7 +1179,7 @@ function stremioSearchMetaToItem(
   meta: StremioMeta,
   mediaType: StremioMediaType,
   requestedId?: string,
-  options: { suppressMovieAutoplay?: boolean } = {},
+  options: { suppressMovieAutoplay?: boolean; officialRating?: string } = {},
 ) {
   const { itemId, sourceId } = stremioSearchMetaIds(meta, mediaType)
   const id = requestedId ?? itemId
@@ -1205,6 +1211,7 @@ function stremioSearchMetaToItem(
     Overview:           meta.overview || meta.description,
     Genres:             genres,
     GenreItems:         genreItems(genres),
+    OfficialRating:     options.officialRating || undefined,
     ExternalUrls:       meta.id.startsWith('tmdb:')
       ? [{ Name: 'TMDB', Url: `https://www.themoviedb.org/${mediaType === 'series' ? 'tv' : 'movie'}/${meta.id.slice(5)}` }]
       : stremioMetaExternalUrls(meta, mediaType),
@@ -1499,6 +1506,55 @@ function isStremioErrorMeta(meta: StremioMeta): boolean {
   return stremioMetaName(meta).startsWith('[x]') || stremioMetaName(meta).startsWith('[❌]')
 }
 
+function stremioMetaTmdbId(meta: StremioMeta): number | null {
+  if (!meta.id.startsWith('tmdb:')) return null
+  const tmdbId = Number.parseInt(meta.id.slice(5), 10)
+  return Number.isFinite(tmdbId) && tmdbId > 0 ? tmdbId : null
+}
+
+function stremioMetaImdbId(meta: StremioMeta): string {
+  const imdbId = meta.imdb_id || meta.imdbId || (meta.id.startsWith('tt') ? meta.id : '')
+  return /^tt\d+$/i.test(imdbId) ? imdbId : ''
+}
+
+function stremioMetaTvdbId(meta: StremioMeta): number | undefined {
+  const raw = (meta as StremioMeta & { tvdb_id?: number | string; tvdbId?: number | string }).tvdb_id
+    ?? (meta as StremioMeta & { tvdb_id?: number | string; tvdbId?: number | string }).tvdbId
+  const tvdbId = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number.parseInt(raw, 10) : NaN
+  return Number.isFinite(tvdbId) && tvdbId > 0 ? tvdbId : undefined
+}
+
+function stremioRatingCacheKey(meta: StremioMeta, mediaType: StremioMediaType): string {
+  return `${mediaType}:${meta.id}:${stremioMetaImdbId(meta)}:${stremioMetaTmdbId(meta) ?? ''}:${stremioMetaTvdbId(meta) ?? ''}`
+}
+
+async function stremioOfficialRating(meta: StremioMeta, mediaType: StremioMediaType): Promise<string> {
+  pruneStremioCaches()
+  const key = stremioRatingCacheKey(meta, mediaType)
+  const cached = stremioRatingCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) return cached.rating
+
+  const tmdbId = stremioMetaTmdbId(meta)
+  const imdbId = stremioMetaImdbId(meta)
+  const rating = mediaType === 'movie'
+    ? await fetchMovieOfficialRatingByIds({ tmdbId, imdbId })
+    : await fetchShowOfficialRatingByIds({ tmdbId, imdbId, tvdbId: stremioMetaTvdbId(meta) })
+  stremioRatingCache.set(key, { rating, expiresAt: Date.now() + STREMIO_SEARCH_CACHE_TTL_MS })
+  trimCacheMap(stremioRatingCache, STREMIO_CACHE_MAX_ITEMS)
+  return rating
+}
+
+async function canUserAccessStremioMeta(user: AppUser, meta: StremioMeta, mediaType: StremioMediaType): Promise<boolean> {
+  if (!hasRatingLimit(user)) return true
+  const rating = await stremioOfficialRating(meta, mediaType)
+  return canUserAccessKnownRating(user.maxRating, rating)
+}
+
+async function stremioRatingForVisibleMeta(user: AppUser, meta: StremioMeta, mediaType: StremioMediaType): Promise<string> {
+  if (!hasRatingLimit(user)) return ''
+  return stremioOfficialRating(meta, mediaType)
+}
+
 async function buildSearchResultItems(
   searchTerm: string,
   includeTypes: string,
@@ -1531,25 +1587,27 @@ async function buildSearchResultItems(
   const localShowIds = new Set(localShows.map(show => show.tmdbId))
   const localMovieImdbIds = new Set(localMovies.map(movie => movie.imdbId).filter(Boolean))
   const localShowImdbIds = new Set(localShows.map(show => show.imdbId).filter(Boolean))
-  const stremioSearchMetas = stremioMetas
-    .filter(meta => {
-      const mediaType = String(meta.type ?? '').toLowerCase() as StremioMediaType
-      if (mediaType !== 'movie' && mediaType !== 'series') return false
-      const tmdbId = meta.id.startsWith('tmdb:') ? Number.parseInt(meta.id.slice(5), 10) : NaN
-      const imdbId = meta.imdb_id || meta.imdbId || (meta.id.startsWith('tt') ? meta.id : '')
-      if (mediaType === 'movie') {
-        if (Number.isFinite(tmdbId) && localMovieIds.has(tmdbId)) return false
-        if (imdbId && localMovieImdbIds.has(imdbId)) return false
-      } else {
-        if (Number.isFinite(tmdbId) && localShowIds.has(tmdbId)) return false
-        if (imdbId && localShowImdbIds.has(imdbId)) return false
-      }
-      return true
-    })
+  const stremioSearchMetas: StremioMeta[] = []
+  for (const meta of stremioMetas) {
+    const mediaType = String(meta.type ?? '').toLowerCase() as StremioMediaType
+    if (mediaType !== 'movie' && mediaType !== 'series') continue
+    const tmdbId = stremioMetaTmdbId(meta)
+    const imdbId = stremioMetaImdbId(meta)
+    if (mediaType === 'movie') {
+      if (tmdbId && localMovieIds.has(tmdbId)) continue
+      if (imdbId && localMovieImdbIds.has(imdbId)) continue
+    } else {
+      if (tmdbId && localShowIds.has(tmdbId)) continue
+      if (imdbId && localShowImdbIds.has(imdbId)) continue
+    }
+    if (!await canUserAccessStremioMeta(user, meta, mediaType)) continue
+    stremioSearchMetas.push(meta)
+  }
   const stremioSearchItems = await Promise.all(stremioSearchMetas.map(async meta => {
     const mediaType = String(meta.type ?? 'movie').toLowerCase() === 'series' ? 'series' : 'movie'
     const hydrated = mediaType === 'series' ? await hydrateStremioSeriesMeta(meta) : meta
-    const item = stremioSearchMetaToItem(hydrated, mediaType) as Record<string, unknown>
+    const rating = await stremioRatingForVisibleMeta(user, meta, mediaType)
+    const item = stremioSearchMetaToItem(hydrated, mediaType, undefined, { officialRating: rating }) as Record<string, unknown>
     return mediaType === 'movie' ? searchMovieAutoplayItem(item) : item
   }))
 
@@ -2138,6 +2196,9 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const stremioSeries = ParentId ? idToStremioSearchMeta(ParentId) : null
     if (stremioSeries?.mediaType === 'series') {
+      if (!await canUserAccessStremioMeta(user, stremioSeries.meta, 'series')) {
+        return { Items: [], TotalRecordCount: 0, StartIndex: offset }
+      }
       const seriesMeta = await hydrateStremioSeriesMeta(stremioSeries.meta)
       const visibleEpisodes = await visibleStremioEpisodes(seriesMeta)
       if (includeTypes.includes('episode')) {
@@ -2157,6 +2218,9 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const stremioSeasonRef = ParentId ? idToStremioSeason(ParentId) : null
     if (stremioSeasonRef) {
+      if (!await canUserAccessStremioMeta(user, stremioSeasonRef.series, 'series')) {
+        return { Items: [], TotalRecordCount: 0, StartIndex: offset }
+      }
       const episodes = (await visibleStremioEpisodes(stremioSeasonRef.series))
         .filter(ep => stremioEpisodeSeasonNumber(ep) === stremioSeasonRef.seasonNumber)
       return {
@@ -2546,6 +2610,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const stremioEpisode = idToStremioEpisode(id)
     if (stremioEpisode) {
+      if (!await canUserAccessStremioMeta(currentUser, stremioEpisode.series, 'series')) return reply.code(404).send({ error: 'Not found' })
       const item = stremioEpisodeToItem(stremioEpisode.series, stremioEpisode.episode) as Record<string, unknown>
       if (!config.mediaSourceSelection) return item
       const { series, episode } = stremioEpisode
@@ -2562,14 +2627,19 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     }
 
     const stremioSeason = idToStremioSeason(id)
-    if (stremioSeason) return stremioSeasonToItem(stremioSeason.series, stremioSeason.seasonNumber)
+    if (stremioSeason) {
+      if (!await canUserAccessStremioMeta(currentUser, stremioSeason.series, 'series')) return reply.code(404).send({ error: 'Not found' })
+      return stremioSeasonToItem(stremioSeason.series, stremioSeason.seasonNumber)
+    }
 
     const stremioSearch = idToStremioSearchMeta(id)
     if (stremioSearch) {
+      if (!await canUserAccessStremioMeta(currentUser, stremioSearch.meta, stremioSearch.mediaType)) return reply.code(404).send({ error: 'Not found' })
+      const rating = await stremioRatingForVisibleMeta(currentUser, stremioSearch.meta, stremioSearch.mediaType)
       const meta = stremioSearch.mediaType === 'series'
         ? await hydrateStremioSeriesMeta(stremioSearch.meta)
         : stremioSearch.meta
-      const item = stremioSearchMetaToItem(meta, stremioSearch.mediaType, stremioSearch.requestedId) as Record<string, unknown>
+      const item = stremioSearchMetaToItem(meta, stremioSearch.mediaType, stremioSearch.requestedId, { officialRating: rating }) as Record<string, unknown>
       if (stremioSearch.mediaType !== 'movie') return item
       const movieItem = searchMovieAutoplayItem(item)
       const externalId = meta.imdb_id || meta.imdbId || meta.id
@@ -2696,6 +2766,9 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const { seriesId } = req.params as { seriesId: string }
     const stremioSeries = idToStremioSearchMeta(seriesId)
     if (stremioSeries?.mediaType === 'series') {
+      if (!await canUserAccessStremioMeta(user, stremioSeries.meta, 'series')) {
+        return { Items: [], TotalRecordCount: 0, StartIndex: 0 }
+      }
       const seriesMeta = await hydrateStremioSeriesMeta(stremioSeries.meta)
       const visibleEpisodes = await visibleStremioEpisodes(seriesMeta)
       const seasonNumbers = stremioSeriesSeasons(visibleEpisodes)
@@ -2731,6 +2804,9 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const SeasonId = q.seasonid
     const stremioSeries = idToStremioSearchMeta(seriesId)
     if (stremioSeries?.mediaType === 'series') {
+      if (!await canUserAccessStremioMeta(user, stremioSeries.meta, 'series')) {
+        return { Items: [], TotalRecordCount: 0, StartIndex: 0 }
+      }
       const seriesMeta = await hydrateStremioSeriesMeta(stremioSeries.meta)
       const stremioSeason = SeasonId ? idToStremioSeason(SeasonId) : null
       const visibleEpisodes = await visibleStremioEpisodes(seriesMeta)
@@ -2806,6 +2882,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const stremioEpisode = idToStremioEpisode(id)
     if (stremioEpisode) {
+      if (rootFolderUser && !await canUserAccessStremioMeta(rootFolderUser, stremioEpisode.series, 'series')) return reply.code(404).send()
       const path = stremioEpisode.episode.poster || stremioEpisode.series.poster
       if (path) return sendImageUrl(reply, headers, path, 'poster', query)
       return reply.code(404).send()
@@ -2813,6 +2890,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const stremioSeason = idToStremioSeason(id)
     if (stremioSeason) {
+      if (rootFolderUser && !await canUserAccessStremioMeta(rootFolderUser, stremioSeason.series, 'series')) return reply.code(404).send()
       if (stremioSeason.series.poster) return sendImageUrl(reply, headers, stremioSeason.series.poster, 'poster', query)
       return reply.code(404).send()
     }
@@ -2820,6 +2898,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const stremioSearch = idToStremioSearchMeta(id)
     if (stremioSearch) {
       const { meta } = stremioSearch
+      if (rootFolderUser && !await canUserAccessStremioMeta(rootFolderUser, meta, stremioSearch.mediaType)) return reply.code(404).send()
       if (isLogo && meta.logo) return sendImageUrl(reply, headers, meta.logo, 'logo', query)
       if (isThumb && meta.background) return sendImageUrl(reply, headers, meta.background, 'backdrop', query)
       if (isBackdrop && meta.background) return sendImageUrl(reply, headers, meta.background, 'backdrop', query)
@@ -3043,6 +3122,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const stremioEpisode = idToStremioEpisode(id)
     if (stremioEpisode) {
       const { series, episode } = stremioEpisode
+      if (!await canUserAccessStremioMeta(user, series, 'series')) return reply.code(404).send({ error: 'Not found' })
       const externalId = episode.id || `${series.id}:${stremioEpisodeSeasonNumber(episode)}:${stremioEpisodeNumber(episode)}`
       const playPath = `/play/stremio/series/${encodeURIComponent(externalId)}`
       const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
@@ -3075,6 +3155,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     if (stremioSearch) {
       const { meta, mediaType, sourceId } = stremioSearch
       if (mediaType !== 'movie') return reply.code(404).send({ error: 'Not playable' })
+      if (!await canUserAccessStremioMeta(user, meta, mediaType)) return reply.code(404).send({ error: 'Not found' })
       const externalId = meta.imdb_id || meta.imdbId || meta.id
       const playPath = `/play/stremio/movie/${encodeURIComponent(externalId)}`
       const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
@@ -3233,6 +3314,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const stremioEpisode = idToStremioEpisode(id)
     if (stremioEpisode) {
       const { series, episode } = stremioEpisode
+      if (!await canUserAccessStremioMeta(user, series, 'series')) return reply.code(404).send()
       const externalId = episode.id || `${series.id}:${stremioEpisodeSeasonNumber(episode)}:${stremioEpisodeNumber(episode)}`
       const playPath = `/play/stremio/series/${encodeURIComponent(externalId)}`
       return reply.redirect(signedPlaybackUrlForMediaSource(origin, playPath, mediaSourceId), 302)
@@ -3242,6 +3324,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     if (stremioSearch) {
       const { meta, mediaType } = stremioSearch
       if (mediaType !== 'movie') return reply.code(404).send()
+      if (!await canUserAccessStremioMeta(user, meta, mediaType)) return reply.code(404).send()
       const externalId = meta.imdb_id || meta.imdbId || meta.id
       const playPath = `/play/stremio/movie/${encodeURIComponent(externalId)}`
       return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -3327,7 +3327,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       if (!await canUserAccessStremioMeta(user, meta, mediaType)) return reply.code(404).send()
       const externalId = meta.imdb_id || meta.imdbId || meta.id
       const playPath = `/play/stremio/movie/${encodeURIComponent(externalId)}`
-      return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
+      return reply.redirect(signedPlaybackUrlForMediaSource(origin, playPath, mediaSourceId), 302)
     }
 
     const epRef = idToEpisode(id)
@@ -3347,7 +3347,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       if (!canUserAccessMovie(user, movie)) return reply.code(404).send()
       if (!isMovieVisibleToLibrary(movie)) return reply.code(409).send({ error: 'Title not yet available', message: 'Not Yet Released' })
       const playPath = `/play/${movie.imdbId}`
-      return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
+      return reply.redirect(signedPlaybackUrlForMediaSource(origin, playPath, mediaSourceId), 302)
     }
 
     const tmdbId = idToTmdb(id)

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -16,6 +16,7 @@ import {
 import type { Movie, Show, Season, Episode } from '../db.js'
 import { buildPlaybackOrigin, createSignedPlaybackUrl } from '../play-auth.js'
 import { mdblistListPathFromUrl } from '../mdblist.js'
+import { searchStremioMetas, type StremioMediaType, type StremioMeta } from '../sootio.js'
 
 // ── ID helpers ────────────────────────────────────────────────────────────────
 // Real Jellyfin uses GUIDs for all IDs. Infuse validates this client-side.
@@ -28,6 +29,10 @@ import { mdblistListPathFromUrl } from '../mdblist.js'
 //   Episode: 00000000-0000-4000-8003-{showTmdbId 6 hex}{seasonNum 3 hex}{episodeNum 3 hex}
 //   Search Movie:  00000000-0000-4000-8004-{tmdbId 12 hex}
 //   Search Series: 00000000-0000-4000-8005-{tmdbId 12 hex}
+//   Stremio Search:    md5(stremio:item:{mediaType}:{meta id}) 32 hex
+//   Stremio Source:    md5(stremio:source:{mediaType}:{meta id}) 32 hex
+//   Stremio Season:    00000000-0000-4000-8008-{md5(series id/season) last 12 hex}
+//   Stremio Episode:   00000000-0000-4000-8009-{md5(series id/episode id) last 12 hex}
 
 const MOVIES_FOLDER_ID = 'a0000000-0000-4000-8000-000000000001'
 const SHOWS_FOLDER_ID  = 'a0000000-0000-4000-8000-000000000002'
@@ -39,6 +44,7 @@ const FOLDER_ID = MOVIES_FOLDER_ID
 const API_LIBRARY_FILTER = { availableOnly: true as const }
 const READ_CACHE_TTL_MS = 3_000
 const IMAGE_PROXY_TTL_MS = 60 * 60 * 1000
+const STREMIO_SEARCH_CACHE_TTL_MS = 30 * 60 * 1000
 const PLAYED_COMPLETION_THRESHOLD = 0.95
 const NEXT_UP_PROGRESS_THRESHOLD = 0.60
 const JELLYFIN_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000
@@ -49,6 +55,9 @@ const jellyfinTokens = new Map<string, { userId: string; expiresAt: number }>()
 const loginAttempts = new Map<string, { count: number; resetAt: number }>()
 const proxiedImageCache = new Map<string, { buffer: Buffer; contentType: string; expiresAt: number }>()
 const traktCollectionSummaryCache = new Map<string, { expiresAt: number; summaries: TraktCollectionSummary[] }>()
+const stremioSearchCache = new Map<string, { meta: StremioMeta; mediaType: StremioMediaType; itemId: string; sourceId: string; expiresAt: number }>()
+const stremioSeasonCache = new Map<string, { series: StremioMeta; seasonNumber: number; expiresAt: number }>()
+const stremioEpisodeCache = new Map<string, { series: StremioMeta; episode: StremioMeta; expiresAt: number }>()
 type JellyfinRouteOptions = {
   prewarmPlayback?: (playPath: string, label: string) => void
   registerPlaybackItem?: (itemId: string, playPath: string) => void
@@ -117,6 +126,67 @@ function idToTraktCollectionSlug(id: string): string | null {
   const m = id.match(/^00000000-0000-4000-8006-([0-9a-f]{12})$/i)
   if (!m) return null
   return config.traktLists.find(slug => traktCollectionSlugToId(slug) === id) ?? null
+}
+
+function stremioSearchMetaIds(meta: StremioMeta, mediaType: StremioMediaType): { itemId: string; sourceId: string } {
+  const itemId = createHash('md5').update(`stremio:item:${mediaType}:${meta.id}`).digest('hex')
+  const sourceId = createHash('md5').update(`stremio:source:${mediaType}:${meta.id}`).digest('hex')
+  const cached = { meta, mediaType, itemId, sourceId, expiresAt: Date.now() + STREMIO_SEARCH_CACHE_TTL_MS }
+  stremioSearchCache.set(itemId, cached)
+  stremioSearchCache.set(sourceId, cached)
+  return { itemId, sourceId }
+}
+
+function stremioSearchMetaToId(meta: StremioMeta, mediaType: StremioMediaType): string {
+  return stremioSearchMetaIds(meta, mediaType).itemId
+}
+
+function idToStremioSearchMeta(id: string): { meta: StremioMeta; mediaType: StremioMediaType; itemId: string; sourceId: string; requestedId: string } | null {
+  if (!/^[0-9a-f]{32}$/i.test(id)) return null
+  const cached = stremioSearchCache.get(id)
+  if (!cached) return null
+  if (cached.expiresAt <= Date.now()) {
+    stremioSearchCache.delete(cached.itemId)
+    stremioSearchCache.delete(cached.sourceId)
+    return null
+  }
+  return { meta: cached.meta, mediaType: cached.mediaType, itemId: cached.itemId, sourceId: cached.sourceId, requestedId: id }
+}
+
+function stremioSeasonToId(series: StremioMeta, seasonNumber: number): string {
+  const hash = createHash('md5').update(`stremio-season:${series.id}:${seasonNumber}`).digest('hex')
+  const id = `00000000-0000-4000-8008-${hash.slice(-12)}`
+  stremioSeasonCache.set(id, { series, seasonNumber, expiresAt: Date.now() + STREMIO_SEARCH_CACHE_TTL_MS })
+  return id
+}
+
+function idToStremioSeason(id: string): { series: StremioMeta; seasonNumber: number } | null {
+  if (!/^00000000-0000-4000-8008-[0-9a-f]{12}$/i.test(id)) return null
+  const cached = stremioSeasonCache.get(id)
+  if (!cached) return null
+  if (cached.expiresAt <= Date.now()) {
+    stremioSeasonCache.delete(id)
+    return null
+  }
+  return { series: cached.series, seasonNumber: cached.seasonNumber }
+}
+
+function stremioEpisodeToId(series: StremioMeta, episode: StremioMeta): string {
+  const hash = createHash('md5').update(`stremio-episode:${series.id}:${episode.id || episode.season}:${episode.episode || episode.number}`).digest('hex')
+  const id = `00000000-0000-4000-8009-${hash.slice(-12)}`
+  stremioEpisodeCache.set(id, { series, episode, expiresAt: Date.now() + STREMIO_SEARCH_CACHE_TTL_MS })
+  return id
+}
+
+function idToStremioEpisode(id: string): { series: StremioMeta; episode: StremioMeta } | null {
+  if (!/^00000000-0000-4000-8009-[0-9a-f]{12}$/i.test(id)) return null
+  const cached = stremioEpisodeCache.get(id)
+  if (!cached) return null
+  if (cached.expiresAt <= Date.now()) {
+    stremioEpisodeCache.delete(id)
+    return null
+  }
+  return { series: cached.series, episode: cached.episode }
 }
 
 function seasonToId(showTmdbId: number, seasonNum: number): string {
@@ -777,6 +847,230 @@ function showToSeriesItem(s: Show, userId = DEFAULT_ADMIN_USER_ID) {
   }
 }
 
+function stremioMetaName(meta: StremioMeta): string {
+  return meta.name || meta.title || meta.id
+}
+
+function stremioMetaYear(meta: StremioMeta): number | undefined {
+  if (typeof meta.year === 'number') return meta.year
+  if (typeof meta.year === 'string') {
+    const parsed = Number.parseInt(meta.year, 10)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  const releaseInfo = String(meta.releaseInfo ?? '')
+  const match = releaseInfo.match(/\b(19\d{2}|20\d{2})\b/)
+  return match ? Number.parseInt(match[1], 10) : undefined
+}
+
+function stremioRuntimeTicks(meta: StremioMeta, fallbackMins: number): number {
+  const runtime = String(meta.runtime ?? '')
+  const hours = runtime.match(/(\d+)\s*h/i)
+  const minutes = runtime.match(/(\d+)\s*m/i)
+  const plainMinutes = runtime.match(/^\s*(\d+)\s*$/)
+  const totalMins = hours || minutes
+    ? (hours ? Number.parseInt(hours[1], 10) * 60 : 0) + (minutes ? Number.parseInt(minutes[1], 10) : 0)
+    : plainMinutes ? Number.parseInt(plainMinutes[1], 10) : fallbackMins
+  return totalMins * 60 * 10_000_000
+}
+
+function stremioMetaExternalUrls(meta: StremioMeta, mediaType: StremioMediaType) {
+  const urls = []
+  const imdbId = meta.imdb_id || meta.imdbId || (meta.id.startsWith('tt') ? meta.id : '')
+  if (imdbId) urls.push({ Name: 'IMDb', Url: `https://www.imdb.com/title/${imdbId}` })
+  if (meta.id.startsWith('tmdb:')) {
+    urls.push({
+      Name: 'TMDB',
+      Url: `https://www.themoviedb.org/${mediaType === 'series' ? 'tv' : 'movie'}/${meta.id.slice(5)}`,
+    })
+  }
+  return urls
+}
+
+function stremioStubPath(id: string): string {
+  return `fetcherr://stremio/${id}`
+}
+
+function stremioSearchTypeLabel(includeTypes: string): string {
+  if (!includeTypes) return 'Movie,Series'
+  const labels = [
+    includeTypes.includes('movie') ? 'Movie' : '',
+    includeTypes.includes('series') ? 'Series' : '',
+  ].filter(Boolean)
+  return labels.length ? labels.join(',') : includeTypes
+}
+
+function stremioSearchMetaToItem(meta: StremioMeta, mediaType: StremioMediaType, requestedId?: string) {
+  const { itemId, sourceId } = stremioSearchMetaIds(meta, mediaType)
+  const id = requestedId ?? itemId
+  const name = stremioMetaName(meta)
+  const genres = meta.genres ?? meta.genre ?? []
+  const runtimeTicks = stremioRuntimeTicks(meta, mediaType === 'movie' ? 90 : 45)
+  const path = stremioStubPath(meta.id)
+  const primaryTag = meta.poster ? createHash('md5').update(meta.poster).digest('hex') : undefined
+  const logoTag = meta.logo ? createHash('sha1').update(meta.logo).digest('hex').slice(0, 16) : undefined
+  const isMovie = mediaType === 'movie'
+  const year = stremioMetaYear(meta)
+  const date = meta.released ? `${meta.released.slice(0, 10)}T00:00:00.0000000Z` : year ? `${year}-01-01T00:00:00.0000000Z` : undefined
+  return {
+    Id:                 id,
+    ServerId:           SERVER_GUID,
+    Name:               name,
+    SortName:           name.replace(/^(the|a|an)\s+/i, '').toLowerCase(),
+    Type:               isMovie ? 'Movie' : 'Series',
+    MediaType:          isMovie ? 'Video' : undefined,
+    VideoType:          isMovie ? 'VideoFile' : undefined,
+    LocationType:       'Remote',
+    PlayAccess:         'Full',
+    IsPlayable:         isMovie,
+    CanDelete:          false,
+    CanDownload:        isMovie,
+    ChannelId:          null,
+    ProductionYear:     year,
+    Overview:           meta.overview || meta.description,
+    Genres:             genres,
+    GenreItems:         genreItems(genres),
+    ExternalUrls:       meta.id.startsWith('tmdb:')
+      ? [{ Name: 'TMDB', Url: `https://www.themoviedb.org/${mediaType === 'series' ? 'tv' : 'movie'}/${meta.id.slice(5)}` }]
+      : stremioMetaExternalUrls(meta, mediaType),
+    DateCreated:        new Date().toISOString(),
+    PremiereDate:       date,
+    EndDate:            date,
+    RunTimeTicks:       isMovie ? runtimeTicks : undefined,
+    Etag:               createHash('md5').update(`stremio:etag:${mediaType}:${meta.id}`).digest('hex'),
+    DisplayPreferencesId: createHash('md5').update(`stremio:display:${mediaType}:${meta.id}`).digest('hex'),
+    IsFolder:           !isMovie,
+    Path:               path,
+    EnableMediaSourceDisplay: isMovie ? true : undefined,
+    ChildCount:         isMovie ? undefined : (meta.videos?.length ?? 0),
+    RecursiveItemCount: isMovie ? undefined : (meta.videos?.length ?? 0),
+    ImageTags:          {
+      ...(primaryTag ? { Primary: primaryTag } : {}),
+      ...(logoTag ? { Logo: logoTag } : {}),
+    },
+    PrimaryImageAspectRatio: primaryTag ? 0.6666666666666666 : undefined,
+    BackdropImageTags:  meta.background ? [createHash('sha1').update(meta.background).digest('hex').slice(0, 16)] : [],
+    ParentId:           null,
+    ProviderIds:        {
+      ...(meta.id.startsWith('tmdb:') ? { Tmdb: meta.id.slice(5) } : {}),
+      Stremio: meta.id,
+    },
+    UserData:           userDataForItem(id, { played: false, playCount: 0, positionTicks: 0, lastPlayedDate: '' }, runtimeTicks),
+    MediaSources:       isMovie ? [{
+      Protocol:             'Http',
+      Id:                   sourceId,
+      Type:                 'Default',
+      Container:            'mkv',
+      Size:                 0,
+      Name:                 name,
+      Path:                 path,
+      IsRemote:             false,
+      RunTimeTicks:         runtimeTicks,
+      SupportsTranscoding:  true,
+      SupportsDirectStream: true,
+      SupportsDirectPlay:   true,
+      SupportsProbing:      true,
+      HasSegments:          false,
+      VideoType:            'VideoFile',
+      IsInfiniteStream:     false,
+      RequiresOpening:      false,
+      RequiresClosing:      false,
+    }] : undefined,
+  }
+}
+
+function stremioEpisodeSeasonNumber(ep: StremioMeta): number {
+  return ep.season ?? 1
+}
+
+function stremioEpisodeNumber(ep: StremioMeta): number {
+  return ep.episode ?? ep.number ?? 1
+}
+
+function stremioSeriesSeasons(series: StremioMeta[]) {
+  return [...new Set(series.map(stremioEpisodeSeasonNumber).filter(n => Number.isFinite(n) && n > 0))].sort((a, b) => a - b)
+}
+
+function stremioSeasonToItem(series: StremioMeta, seasonNumber: number) {
+  const id = stremioSeasonToId(series, seasonNumber)
+  const seriesId = stremioSearchMetaToId(series, 'series')
+  const episodes = (series.videos ?? []).filter(ep => stremioEpisodeSeasonNumber(ep) === seasonNumber)
+  return {
+    Id:             id,
+    ServerId:       SERVER_GUID,
+    Name:           `Season ${seasonNumber}`,
+    SeriesName:     stremioMetaName(series),
+    SeriesId:       seriesId,
+    Type:           'Season',
+    LocationType:   'Virtual',
+    IndexNumber:    seasonNumber,
+    ParentIndexNumber: seasonNumber,
+    ParentId:       seriesId,
+    IsFolder:       true,
+    ChildCount:     episodes.length,
+    RecursiveItemCount: episodes.length,
+    ImageTags:      series.poster ? { Primary: createHash('sha1').update(series.poster).digest('hex').slice(0, 16) } : {},
+    UserData:       userDataForItem(id, { played: false, playCount: 0, positionTicks: 0, lastPlayedDate: '' }),
+  }
+}
+
+function stremioEpisodeToItem(series: StremioMeta, episode: StremioMeta) {
+  const id = stremioEpisodeToId(series, episode)
+  const seasonNumber = stremioEpisodeSeasonNumber(episode)
+  const episodeNumber = stremioEpisodeNumber(episode)
+  const seasonId = stremioSeasonToId(series, seasonNumber)
+  const seriesId = stremioSearchMetaToId(series, 'series')
+  const name = stremioMetaName(episode) || `Episode ${episodeNumber}`
+  const runtimeTicks = stremioRuntimeTicks(episode, 45)
+  const path = stremioStubPath(episode.id || `${series.id}:${seasonNumber}:${episodeNumber}`)
+  return {
+    Id:                 id,
+    ServerId:           SERVER_GUID,
+    Name:               name,
+    SeriesName:         stremioMetaName(series),
+    SeriesId:           seriesId,
+    SeasonId:           seasonId,
+    Type:               'Episode',
+    MediaType:          'Video',
+    VideoType:          'VideoFile',
+    LocationType:       'Remote',
+    PlayAccess:         'Full',
+    IsPlayable:         true,
+    CanDownload:        true,
+    IsFolder:           false,
+    IndexNumber:        episodeNumber,
+    ParentIndexNumber:  seasonNumber,
+    ParentId:           seasonId,
+    Overview:           episode.overview || episode.description,
+    ProductionYear:     stremioMetaYear(episode) ?? stremioMetaYear(series),
+    RunTimeTicks:       runtimeTicks,
+    Path:               path,
+    EnableMediaSourceDisplay: true,
+    ImageTags:          (episode.poster || series.poster) ? { Primary: createHash('sha1').update(episode.poster || series.poster || '').digest('hex').slice(0, 16) } : {},
+    ProviderIds:        { Stremio: episode.id || `${series.id}:${seasonNumber}:${episodeNumber}` },
+    UserData:           userDataForItem(id, { played: false, playCount: 0, positionTicks: 0, lastPlayedDate: '' }, runtimeTicks),
+    MediaSources: [{
+      Protocol:             'Http',
+      Id:                   id,
+      Type:                 'Default',
+      Container:            'mkv',
+      Size:                 0,
+      Name:                 name,
+      Path:                 path,
+      IsRemote:             false,
+      RunTimeTicks:         runtimeTicks,
+      SupportsTranscoding:  true,
+      SupportsDirectStream: true,
+      SupportsDirectPlay:   true,
+      SupportsProbing:      true,
+      HasSegments:          false,
+      VideoType:            'VideoFile',
+      IsInfiniteStream:     false,
+      RequiresOpening:      false,
+      RequiresClosing:      false,
+    }],
+  }
+}
+
 function movieToSearchItem(m: Movie) {
   const genres: string[] = JSON.parse(m.genres || '[]')
   const id = searchMovieTmdbToId(m.tmdbId)
@@ -964,6 +1258,10 @@ function compareEpisodeOrder(a: Pick<Episode, 'seasonNumber' | 'episodeNumber'>,
   return a.episodeNumber - b.episodeNumber
 }
 
+function isStremioErrorMeta(meta: StremioMeta): boolean {
+  return stremioMetaName(meta).startsWith('[x]') || stremioMetaName(meta).startsWith('[❌]')
+}
+
 async function buildSearchResultItems(
   searchTerm: string,
   includeTypes: string,
@@ -975,6 +1273,15 @@ async function buildSearchResultItems(
 ) {
   const wantMovies = !includeTypes || includeTypes.includes('movie')
   const wantShows = !includeTypes || includeTypes.includes('series')
+  const stremioTypes: StremioMediaType[] = [
+    ...(wantMovies ? ['movie' as const] : []),
+    ...(wantShows ? ['series' as const] : []),
+  ]
+
+  const rawStremioMetas = stremioTypes.length
+    ? await searchStremioMetas(searchTerm, stremioTypes).catch(() => [])
+    : []
+  const stremioMetas = rawStremioMetas.filter(meta => !isStremioErrorMeta(meta))
 
   const localMovies = wantMovies
     ? filterMoviesForUser(user, listMovies({ search: searchTerm, sortBy, sortOrder, limit: 10_000, offset: 0, userId: user.id, ...API_LIBRARY_FILTER }))
@@ -983,9 +1290,31 @@ async function buildSearchResultItems(
     ? filterShowsForUser(user, listShows({ search: searchTerm, sortBy, sortOrder, limit: 10_000, offset: 0, userId: user.id, ...API_LIBRARY_FILTER }))
     : []
 
+  const localMovieIds = new Set(localMovies.map(movie => movie.tmdbId))
+  const localShowIds = new Set(localShows.map(show => show.tmdbId))
+  const localMovieImdbIds = new Set(localMovies.map(movie => movie.imdbId).filter(Boolean))
+  const localShowImdbIds = new Set(localShows.map(show => show.imdbId).filter(Boolean))
+  const stremioSearchItems = stremioMetas
+    .filter(meta => {
+      const mediaType = String(meta.type ?? '').toLowerCase() as StremioMediaType
+      if (mediaType !== 'movie' && mediaType !== 'series') return false
+      const tmdbId = meta.id.startsWith('tmdb:') ? Number.parseInt(meta.id.slice(5), 10) : NaN
+      const imdbId = meta.imdb_id || meta.imdbId || (meta.id.startsWith('tt') ? meta.id : '')
+      if (mediaType === 'movie') {
+        if (Number.isFinite(tmdbId) && localMovieIds.has(tmdbId)) return false
+        if (imdbId && localMovieImdbIds.has(imdbId)) return false
+      } else {
+        if (Number.isFinite(tmdbId) && localShowIds.has(tmdbId)) return false
+        if (imdbId && localShowImdbIds.has(imdbId)) return false
+      }
+      return true
+    })
+    .map(meta => stremioSearchMetaToItem(meta, String(meta.type ?? 'movie').toLowerCase() === 'series' ? 'series' : 'movie'))
+
   const combined = [
     ...localMovies.map(movie => movieToItem(movie, user.id)),
     ...localShows.map(show => showToSeriesItem(show, user.id)),
+    ...stremioSearchItems,
   ]
 
   return {
@@ -1524,6 +1853,35 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       return { Items: pagedItems(allShows, offset, limit).map(show => showToSeriesItem(show, user.id)), TotalRecordCount: allShows.length, StartIndex: offset }
     }
 
+    const stremioSeries = ParentId ? idToStremioSearchMeta(ParentId) : null
+    if (stremioSeries?.mediaType === 'series') {
+      if (includeTypes.includes('episode')) {
+        const episodes = stremioSeries.meta.videos ?? []
+        return {
+          Items: pagedItems(episodes, offset, limit).map(ep => stremioEpisodeToItem(stremioSeries.meta, ep)),
+          TotalRecordCount: episodes.length,
+          StartIndex: offset,
+        }
+      }
+      const seasonNumbers = stremioSeriesSeasons(stremioSeries.meta.videos ?? [])
+      return {
+        Items: seasonNumbers.map(seasonNumber => stremioSeasonToItem(stremioSeries.meta, seasonNumber)),
+        TotalRecordCount: seasonNumbers.length,
+        StartIndex: offset,
+      }
+    }
+
+    const stremioSeasonRef = ParentId ? idToStremioSeason(ParentId) : null
+    if (stremioSeasonRef) {
+      const episodes = (stremioSeasonRef.series.videos ?? [])
+        .filter(ep => stremioEpisodeSeasonNumber(ep) === stremioSeasonRef.seasonNumber)
+      return {
+        Items: pagedItems(episodes, offset, limit).map(ep => stremioEpisodeToItem(stremioSeasonRef.series, ep)),
+        TotalRecordCount: episodes.length,
+        StartIndex: offset,
+      }
+    }
+
     // ── Series ID: list seasons ────────────────────────────────────────────────
     const seriesRef = ParentId ? idToShowTmdb(ParentId) : null
     if (seriesRef) {
@@ -1827,6 +2185,15 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       return buildMdblistFolderItem(mdblistUrl, mdblistFolderMembers(currentUser, mdblistUrl).length)
     }
 
+    const stremioEpisode = idToStremioEpisode(id)
+    if (stremioEpisode) return stremioEpisodeToItem(stremioEpisode.series, stremioEpisode.episode)
+
+    const stremioSeason = idToStremioSeason(id)
+    if (stremioSeason) return stremioSeasonToItem(stremioSeason.series, stremioSeason.seasonNumber)
+
+    const stremioSearch = idToStremioSearchMeta(id)
+    if (stremioSearch) return stremioSearchMetaToItem(stremioSearch.meta, stremioSearch.mediaType, stremioSearch.requestedId)
+
     // Episode
     const epRef = idToEpisode(id)
     if (epRef) {
@@ -1913,6 +2280,15 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const user = requestUser(req.headers)
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
     const { seriesId } = req.params as { seriesId: string }
+    const stremioSeries = idToStremioSearchMeta(seriesId)
+    if (stremioSeries?.mediaType === 'series') {
+      const seasonNumbers = stremioSeriesSeasons(stremioSeries.meta.videos ?? [])
+      return {
+        Items: seasonNumbers.map(seasonNumber => stremioSeasonToItem(stremioSeries.meta, seasonNumber)),
+        TotalRecordCount: seasonNumbers.length,
+        StartIndex: 0,
+      }
+    }
     const searchShowTmdbId = idToSearchShowTmdb(seriesId)
     if (searchShowTmdbId) return { Items: [], TotalRecordCount: 0, StartIndex: 0 }
     return withReadCache(`show-seasons:${user.id}:${seriesId}`, async () => {
@@ -1937,6 +2313,18 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const q: Record<string, string> = {}
     for (const [k, v] of Object.entries(rawQ)) q[k.toLowerCase()] = queryValue(v)
     const SeasonId = q.seasonid
+    const stremioSeries = idToStremioSearchMeta(seriesId)
+    if (stremioSeries?.mediaType === 'series') {
+      const stremioSeason = SeasonId ? idToStremioSeason(SeasonId) : null
+      const episodes = stremioSeason
+        ? (stremioSeries.meta.videos ?? []).filter(ep => stremioEpisodeSeasonNumber(ep) === stremioSeason.seasonNumber)
+        : (stremioSeries.meta.videos ?? [])
+      return {
+        Items: episodes.map(ep => stremioEpisodeToItem(stremioSeries.meta, ep)),
+        TotalRecordCount: episodes.length,
+        StartIndex: 0,
+      }
+    }
     const searchShowTmdbId = idToSearchShowTmdb(seriesId)
     if (searchShowTmdbId) return { Items: [], TotalRecordCount: 0, StartIndex: 0 }
     return withReadCache(`show-episodes:${user.id}:${seriesId}:${SeasonId ?? 'all'}`, async () => {
@@ -1996,6 +2384,29 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const mdblistImageUrl = config.mdblistFolders ? idToMdblistListUrl(id) : null
     if (mdblistImageUrl) {
       return sendMdblistFolderImage(mdblistImageUrl, type, query, headers, reply)
+    }
+
+    const stremioEpisode = idToStremioEpisode(id)
+    if (stremioEpisode) {
+      const path = stremioEpisode.episode.poster || stremioEpisode.series.poster
+      if (path) return sendImageUrl(reply, headers, path, 'poster', query)
+      return reply.code(404).send()
+    }
+
+    const stremioSeason = idToStremioSeason(id)
+    if (stremioSeason) {
+      if (stremioSeason.series.poster) return sendImageUrl(reply, headers, stremioSeason.series.poster, 'poster', query)
+      return reply.code(404).send()
+    }
+
+    const stremioSearch = idToStremioSearchMeta(id)
+    if (stremioSearch) {
+      const { meta } = stremioSearch
+      if (isLogo && meta.logo) return sendImageUrl(reply, headers, meta.logo, 'logo', query)
+      if (isThumb && meta.background) return sendImageUrl(reply, headers, meta.background, 'backdrop', query)
+      if (isBackdrop && meta.background) return sendImageUrl(reply, headers, meta.background, 'backdrop', query)
+      if (meta.poster) return sendImageUrl(reply, headers, meta.poster, 'poster', query)
+      return reply.code(404).send()
     }
 
     // Episode primary/backdrop still → fall back to season poster → series poster
@@ -2211,6 +2622,79 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
     const { id } = req.params
 
+    const stremioEpisode = idToStremioEpisode(id)
+    if (stremioEpisode) {
+      const { series, episode } = stremioEpisode
+      const externalId = episode.id || `${series.id}:${stremioEpisodeSeasonNumber(episode)}:${stremioEpisodeNumber(episode)}`
+      const playPath = `/play/stremio/series/${encodeURIComponent(externalId)}`
+      const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
+      const name = `${stremioMetaName(series)} - ${stremioMetaName(episode)}`
+      const runtimeTicks = stremioRuntimeTicks(episode, 45)
+      app.log.info(`playback: Stremio "${name}" → ${playUrl}`)
+      opts.registerPlaybackItem?.(id, playPath)
+      opts.registerPlaybackClient?.(playPath, playbackClientFromHeaders(req.headers))
+      opts.prewarmPlayback?.(playPath, name)
+      return {
+        MediaSources: [{
+          Id:                   id,
+          Name:                 name,
+          Type:                 'Default',
+          Protocol:             'Http',
+          Path:                 playUrl,
+          IsRemote:             true,
+          SupportsDirectPlay:   true,
+          SupportsDirectStream: true,
+          SupportsTranscoding:  false,
+          RequiresOpening:      false,
+          RequiresClosing:      false,
+          Container:            'mkv',
+          RunTimeTicks:         runtimeTicks,
+          MediaStreams: [
+            { Type: 'Video', Index: 0, Codec: 'h264', IsDefault: true },
+            { Type: 'Audio', Index: 1, Codec: 'aac',  IsDefault: true, Language: 'eng' },
+          ],
+        }],
+        PlaySessionId: `fetcherr-${id}`,
+      }
+    }
+
+    const stremioSearch = idToStremioSearchMeta(id)
+    if (stremioSearch) {
+      const { meta, mediaType, sourceId } = stremioSearch
+      if (mediaType !== 'movie') return reply.code(404).send({ error: 'Not playable' })
+      const externalId = meta.imdb_id || meta.imdbId || meta.id
+      const playPath = `/play/stremio/${mediaType}/${encodeURIComponent(externalId)}`
+      const playUrl = createSignedPlaybackUrl(buildPlaybackOrigin(req.headers), playPath)
+      const name = stremioMetaName(meta)
+      const runtimeTicks = stremioRuntimeTicks(meta, 90)
+      app.log.info(`playback: Stremio "${name}" → ${playUrl}`)
+      opts.registerPlaybackItem?.(id, playPath)
+      opts.registerPlaybackClient?.(playPath, playbackClientFromHeaders(req.headers))
+      opts.prewarmPlayback?.(playPath, name)
+      return {
+        MediaSources: [{
+          Id:                   sourceId,
+          Name:                 name,
+          Type:                 'Default',
+          Protocol:             'Http',
+          Path:                 playUrl,
+          IsRemote:             true,
+          SupportsDirectPlay:   true,
+          SupportsDirectStream: true,
+          SupportsTranscoding:  false,
+          RequiresOpening:      false,
+          RequiresClosing:      false,
+          Container:            'mkv',
+          RunTimeTicks:         runtimeTicks,
+          MediaStreams: [
+            { Type: 'Video', Index: 0, Codec: 'h264', IsDefault: true },
+            { Type: 'Audio', Index: 1, Codec: 'aac',  IsDefault: true, Language: 'eng' },
+          ],
+        }],
+        PlaySessionId: `fetcherr-${id}`,
+      }
+    }
+
     // Episode playback
     const epRef = idToEpisode(id)
     if (epRef) {
@@ -2311,6 +2795,23 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
 
     const origin = buildPlaybackOrigin(req.headers as Record<string, string | undefined>)
+
+    const stremioEpisode = idToStremioEpisode(id)
+    if (stremioEpisode) {
+      const { series, episode } = stremioEpisode
+      const externalId = episode.id || `${series.id}:${stremioEpisodeSeasonNumber(episode)}:${stremioEpisodeNumber(episode)}`
+      const playPath = `/play/stremio/series/${encodeURIComponent(externalId)}`
+      return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
+    }
+
+    const stremioSearch = idToStremioSearchMeta(id)
+    if (stremioSearch) {
+      const { meta, mediaType } = stremioSearch
+      if (mediaType !== 'movie') return reply.code(404).send()
+      const externalId = meta.imdb_id || meta.imdbId || meta.id
+      const playPath = `/play/stremio/${mediaType}/${encodeURIComponent(externalId)}`
+      return reply.redirect(createSignedPlaybackUrl(origin, playPath), 302)
+    }
 
     const epRef = idToEpisode(id)
     if (epRef) {

--- a/src/sootio.ts
+++ b/src/sootio.ts
@@ -59,6 +59,10 @@ interface StremioCatalogResponse {
   metas?: StremioMeta[]
 }
 
+interface StremioMetaResponse {
+  meta?: StremioMeta
+}
+
 export interface ProviderFetchMetric {
   time: string
   provider: string
@@ -536,6 +540,12 @@ async function fetchSearchMetasFromProvider(base: string, type: StremioMediaType
   return (json.metas ?? []).map(meta => ({ ...meta, type: meta.type ?? type }))
 }
 
+async function fetchMetaFromProvider(base: string, type: StremioMediaType, id: string): Promise<StremioMeta | null> {
+  const url = `${base}/meta/${type}/${encodeURIComponent(id)}.json`
+  const json = await fetchJson<StremioMetaResponse>(url)
+  return json.meta ? { ...json.meta, type: json.meta.type ?? type } : null
+}
+
 export async function searchStremioMetas(query: string, types: StremioMediaType[]): Promise<StremioMeta[]> {
   const providers = searchProviderBases()
   if (!providers.length || !query.trim()) return []
@@ -558,6 +568,20 @@ export async function searchStremioMetas(query: string, types: StremioMediaType[
     }
   }
   return [...deduped.values()]
+}
+
+export async function fetchStremioMeta(type: StremioMediaType, id: string): Promise<StremioMeta | null> {
+  const providers = searchProviderBases()
+  if (!providers.length || !id.trim()) return null
+
+  const settled = await Promise.allSettled(
+    providers.map(base => fetchMetaFromProvider(base, type, id)),
+  )
+
+  for (const result of settled) {
+    if (result.status === 'fulfilled' && result.value) return result.value
+  }
+  return null
 }
 
 export function summarizeStreamForLog(s: Stream): string {

--- a/src/sootio.ts
+++ b/src/sootio.ts
@@ -18,6 +18,47 @@ export interface Stream {
   providerLabel?: string
 }
 
+export type StremioMediaType = 'movie' | 'series'
+
+export interface StremioMeta {
+  id: string
+  type?: StremioMediaType | string
+  name?: string
+  title?: string
+  poster?: string
+  background?: string
+  logo?: string
+  description?: string
+  overview?: string
+  genres?: string[]
+  genre?: string[]
+  releaseInfo?: string | number
+  year?: string | number
+  imdb_id?: string
+  imdbId?: string
+  runtime?: string
+  released?: string
+  videos?: StremioMeta[]
+  season?: number
+  episode?: number
+  number?: number
+}
+
+interface StremioCatalog {
+  id: string
+  type: string
+  name?: string
+  extra?: Array<{ name?: string; isRequired?: boolean }>
+}
+
+interface StremioManifest {
+  catalogs?: StremioCatalog[]
+}
+
+interface StremioCatalogResponse {
+  metas?: StremioMeta[]
+}
+
 export interface ProviderFetchMetric {
   time: string
   provider: string
@@ -419,6 +460,12 @@ function providerBases(): string[] {
   return [...new Set(urls)]
 }
 
+function searchProviderBases(): string[] {
+  const urls = [...config.stremioSearchProviderUrls]
+  if (!urls.length) urls.push(...providerBases())
+  return [...new Set(urls)]
+}
+
 function isSensitivePathSegment(segment: string): boolean {
   return segment.length >= 16
     || /^[0-9a-f]{12,}$/i.test(segment)
@@ -445,6 +492,72 @@ async function fetchStreams(url: string): Promise<{ streams: Stream[]; status: n
   if (!res.ok) throw new Error(`Stremio add-on returned ${res.status}`)
   const json = await res.json() as { streams?: Stream[] }
   return { streams: json.streams ?? [], status: res.status }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) })
+  if (!res.ok) throw new Error(`Stremio add-on returned ${res.status}`)
+  return await res.json() as T
+}
+
+const manifestCache = new Map<string, { expiresAt: number; value: StremioManifest | null }>()
+const MANIFEST_CACHE_TTL_MS = 5 * 60 * 1000
+
+async function fetchManifest(base: string): Promise<StremioManifest | null> {
+  const cached = manifestCache.get(base)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+
+  try {
+    const value = await fetchJson<StremioManifest>(`${base}/manifest.json`)
+    manifestCache.set(base, { value, expiresAt: Date.now() + MANIFEST_CACHE_TTL_MS })
+    return value
+  } catch {
+    manifestCache.set(base, { value: null, expiresAt: Date.now() + MANIFEST_CACHE_TTL_MS })
+    return null
+  }
+}
+
+function searchCatalog(manifest: StremioManifest | null, type: StremioMediaType): StremioCatalog | null {
+  const catalogs = manifest?.catalogs ?? []
+  return catalogs
+    .filter(catalog => catalog.type?.toLowerCase() === type)
+    .filter(catalog => catalog.extra?.some(extra => extra.name?.toLowerCase() === 'search'))
+    .sort((a, b) => Number(a.id.toLowerCase().includes('people')) - Number(b.id.toLowerCase().includes('people')))
+    [0] ?? null
+}
+
+async function fetchSearchMetasFromProvider(base: string, type: StremioMediaType, query: string): Promise<StremioMeta[]> {
+  const manifest = await fetchManifest(base)
+  const catalog = searchCatalog(manifest, type)
+  if (!catalog) return []
+
+  const url = `${base}/catalog/${type}/${encodeURIComponent(catalog.id)}/search=${encodeURIComponent(query)}.json`
+  const json = await fetchJson<StremioCatalogResponse>(url)
+  return (json.metas ?? []).map(meta => ({ ...meta, type: meta.type ?? type }))
+}
+
+export async function searchStremioMetas(query: string, types: StremioMediaType[]): Promise<StremioMeta[]> {
+  const providers = searchProviderBases()
+  if (!providers.length || !query.trim()) return []
+
+  const settled = await Promise.allSettled(
+    providers.flatMap((base, providerIdx) =>
+      types.map(async type => {
+        const metas = await fetchSearchMetasFromProvider(base, type, query)
+        return metas.map(meta => ({ meta, providerIdx }))
+      }),
+    ),
+  )
+
+  const deduped = new Map<string, StremioMeta>()
+  for (const result of settled) {
+    if (result.status !== 'fulfilled') continue
+    for (const { meta, providerIdx } of result.value) {
+      const key = `${String(meta.type ?? '').toLowerCase()}|${meta.id || meta.imdb_id || meta.imdbId}|${meta.name || meta.title}|${providerIdx}`
+      if (!deduped.has(key)) deduped.set(key, meta)
+    }
+  }
+  return [...deduped.values()]
 }
 
 export function summarizeStreamForLog(s: Stream): string {
@@ -578,6 +691,34 @@ export async function fetchRankedStreams(
     : rankStreamScores(streams, ctx)
   const ranked = summaries.map(score => score.stream)
   console.log(`streams: top candidates for ${imdbId}`)
+  for (const score of summaries.slice(0, 5)) {
+    console.log(`streams: ${scoreSummary(score)} :: ${score.stream.title || score.stream.name}`)
+  }
+  return ranked
+}
+
+export async function fetchRankedStremioStreams(
+  mediaType: StremioMediaType,
+  externalId: string,
+  expectedYear?: number,
+  preferredLanguage = config.preferredAudioLanguage,
+  mediaLanguage = '',
+  playbackClient = '',
+  preserveProviderOrder = false,
+): Promise<Stream[]> {
+  const streams = await fetchStreamsFromProviders(`/stream/${mediaType}/${encodeURIComponent(externalId)}.json`)
+  if (!streams.length) throw new Error(`No streams found for ${mediaType} ${externalId}`)
+  const notWebReadyDirectStreams = streams.filter(isNotWebReadyDirectStream).length
+  if (notWebReadyDirectStreams) {
+    console.log(`streams: ignored ${notWebReadyDirectStreams} notWebReady direct stream${notWebReadyDirectStreams === 1 ? '' : 's'} for ${mediaType} ${externalId}`)
+  }
+  const ctx = { expectedYear, preferredLanguage, mediaLanguage, playbackClient, mediaType: mediaType === 'series' ? 'episode' as const : 'movie' as const }
+  const summaries = preserveProviderOrder
+    ? playableStreamsInProviderOrder(streams, ctx).map(stream => precomputeScore(stream, ctx))
+    : rankStreamScores(streams, ctx)
+  const ranked = summaries.map(score => score.stream)
+  if (!ranked.length) throw new Error(`No ranked streams found for ${mediaType} ${externalId}`)
+  console.log(`streams: top Stremio candidates for ${mediaType} ${externalId}`)
   for (const score of summaries.slice(0, 5)) {
     console.log(`streams: ${scoreSummary(score)} :: ${score.stream.title || score.stream.name}`)
   }

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -1,11 +1,11 @@
 import { config } from './config.js'
 import {
-  upsertMovie, getMovieByTmdbId, type Movie,
-  upsertShow, getShowByTmdbId, type Show,
+  upsertMovie, getMovieByTmdbId, getMovieByImdbId, type Movie,
+  upsertShow, getShowByTmdbId, getShowByImdbId, type Show,
   upsertSeason, getSeasonsForShow, type Season,
   upsertEpisode, type Episode, getAiredEpisodesForSeason, getEffectiveShowMode,
 } from './db.js'
-import { fetchEpisodeStillFallbacks, fetchSeriesLanguage } from './tvdb.js'
+import { fetchContentRatingFallback, fetchEpisodeStillFallbacks, fetchSeriesLanguage } from './tvdb.js'
 
 const BASE = 'https://api.themoviedb.org/3'
 const MISSING_STILL_RETRY_MS = 7 * 24 * 60 * 60 * 1000
@@ -129,6 +129,33 @@ interface TmdbKeywordsResponse {
   results?: TmdbKeyword[]
 }
 
+interface TmdbFindResponse {
+  movie_results?: Array<{ id?: number }>
+  tv_results?: Array<{ id?: number }>
+}
+
+async function findTmdbMovieIdByImdbId(imdbId: string): Promise<number | null> {
+  if (!config.tmdbApiKey || !imdbId.trim()) return null
+  try {
+    const r = await tmdbGet(`/find/${encodeURIComponent(imdbId)}?external_source=imdb_id`) as TmdbFindResponse
+    const tmdbId = r.movie_results?.find(result => typeof result.id === 'number')?.id
+    return tmdbId && Number.isFinite(tmdbId) ? tmdbId : null
+  } catch {
+    return null
+  }
+}
+
+async function findTmdbShowIdByImdbId(imdbId: string): Promise<number | null> {
+  if (!config.tmdbApiKey || !imdbId.trim()) return null
+  try {
+    const r = await tmdbGet(`/find/${encodeURIComponent(imdbId)}?external_source=imdb_id`) as TmdbFindResponse
+    const tmdbId = r.tv_results?.find(result => typeof result.id === 'number')?.id
+    return tmdbId && Number.isFinite(tmdbId) ? tmdbId : null
+  } catch {
+    return null
+  }
+}
+
 interface TmdbImageFile {
   file_path: string
   iso_639_1?: string | null
@@ -229,6 +256,30 @@ export async function fetchMovieByTmdbId(tmdbId: number, listedAt = ''): Promise
   } catch {
     return null
   }
+}
+
+export async function fetchMovieByImdbId(imdbId: string): Promise<Movie | null> {
+  const normalized = imdbId.trim()
+  if (!normalized) return null
+  const cached = getMovieByImdbId(normalized)
+  if (cached) return cached
+  const tmdbId = await findTmdbMovieIdByImdbId(normalized)
+  return tmdbId ? fetchMovieByTmdbId(tmdbId) : null
+}
+
+export async function fetchMovieOfficialRatingByIds(opts: { tmdbId?: number | null; imdbId?: string }): Promise<string> {
+  const tmdbId = opts.tmdbId && Number.isFinite(opts.tmdbId) ? opts.tmdbId : null
+  const imdbId = (opts.imdbId ?? '').trim()
+  let movie = tmdbId ? await fetchMovieByTmdbId(tmdbId) : null
+  if (!movie && imdbId) movie = await fetchMovieByImdbId(imdbId)
+  if (movie?.officialRating) return movie.officialRating
+
+  const fallback = await fetchContentRatingFallback('movie', { imdbId: movie?.imdbId || imdbId })
+  if (fallback && movie) {
+    const { id: _id, ...stored } = movie
+    upsertMovie({ ...stored, officialRating: fallback })
+  }
+  return fallback
 }
 
 export async function fetchMovieCollection(movieTmdbId: number): Promise<MovieCollectionItem[]> {
@@ -358,6 +409,33 @@ export async function fetchShowByTmdbId(tmdbId: number, listedAt = ''): Promise<
   } catch {
     return null
   }
+}
+
+export async function fetchShowByImdbId(imdbId: string): Promise<Show | null> {
+  const normalized = imdbId.trim()
+  if (!normalized) return null
+  const cached = getShowByImdbId(normalized)
+  if (cached) return cached
+  const tmdbId = await findTmdbShowIdByImdbId(normalized)
+  return tmdbId ? fetchShowByTmdbId(tmdbId) : null
+}
+
+export async function fetchShowOfficialRatingByIds(opts: { tmdbId?: number | null; imdbId?: string; tvdbId?: number }): Promise<string> {
+  const tmdbId = opts.tmdbId && Number.isFinite(opts.tmdbId) ? opts.tmdbId : null
+  const imdbId = (opts.imdbId ?? '').trim()
+  let show = tmdbId ? await fetchShowByTmdbId(tmdbId) : null
+  if (!show && imdbId) show = await fetchShowByImdbId(imdbId)
+  if (show?.officialRating) return show.officialRating
+
+  const fallback = await fetchContentRatingFallback('series', {
+    imdbId: show?.imdbId || imdbId,
+    tvdbId: show?.tvdbId || opts.tvdbId,
+  })
+  if (fallback && show) {
+    const { id: _id, ...stored } = show
+    upsertShow({ ...stored, officialRating: fallback })
+  }
+  return fallback
 }
 
 /**

--- a/src/tvdb.ts
+++ b/src/tvdb.ts
@@ -31,6 +31,25 @@ interface TvdbSeriesResponse {
   } | null
 }
 
+interface TvdbContentRating {
+  name?: string | null
+  country?: string | null
+  contentType?: string | null
+}
+
+interface TvdbExtendedRatingResponse {
+  data?: {
+    contentRatings?: TvdbContentRating[]
+  } | null
+}
+
+interface TvdbRemoteSearchResponse {
+  data?: Array<{
+    movie?: { id?: number | null } | null
+    series?: { id?: number | null } | null
+  }>
+}
+
 async function login(): Promise<string> {
   if (!config.tvdbApiKey) throw new Error('TVDB_API_KEY not configured')
   if (cachedToken && Date.now() < cachedTokenExpiresAt) return cachedToken
@@ -99,6 +118,55 @@ export async function fetchSeriesLanguage(tvdbId: number): Promise<string> {
     } catch {
       // ignore and try the next endpoint shape
     }
+  }
+  return ''
+}
+
+function pickUsContentRating(ratings: TvdbContentRating[] | undefined, mediaType: 'movie' | 'series'): string {
+  const expectedContentType = mediaType === 'series' ? 'series' : 'movie'
+  const matches = (ratings ?? []).filter(rating => {
+    const country = (rating.country ?? '').trim().toLowerCase()
+    const contentType = (rating.contentType ?? '').trim().toLowerCase()
+    const isUs = country === 'us' || country === 'usa' || country === 'united states'
+    const matchesType = !contentType || contentType === expectedContentType
+    return isUs && matchesType && rating.name
+  })
+  return matches[0]?.name?.trim() ?? ''
+}
+
+async function fetchContentRatingByTvdbId(mediaType: 'movie' | 'series', tvdbId: number): Promise<string> {
+  if (!config.tvdbApiKey || !tvdbId) return ''
+  const path = mediaType === 'movie' ? `/movies/${tvdbId}/extended?short=true` : `/series/${tvdbId}/extended?short=true`
+  try {
+    const json = await tvdbGet(path) as TvdbExtendedRatingResponse
+    return pickUsContentRating(json.data?.contentRatings, mediaType)
+  } catch {
+    return ''
+  }
+}
+
+export async function fetchContentRatingFallback(
+  mediaType: 'movie' | 'series',
+  opts: { imdbId?: string; tvdbId?: number },
+): Promise<string> {
+  if (!config.tvdbApiKey) return ''
+  if (opts.tvdbId) {
+    const rating = await fetchContentRatingByTvdbId(mediaType, opts.tvdbId)
+    if (rating) return rating
+  }
+
+  const imdbId = (opts.imdbId ?? '').trim()
+  if (!imdbId) return ''
+  try {
+    const json = await tvdbGet(`/search/remoteid/${encodeURIComponent(imdbId)}`) as TvdbRemoteSearchResponse
+    for (const result of json.data ?? []) {
+      const tvdbId = mediaType === 'movie' ? result.movie?.id : result.series?.id
+      if (!tvdbId) continue
+      const rating = await fetchContentRatingByTvdbId(mediaType, tvdbId)
+      if (rating) return rating
+    }
+  } catch {
+    return ''
   }
   return ''
 }

--- a/src/ui/routes.ts
+++ b/src/ui/routes.ts
@@ -181,6 +181,24 @@ async function validateApiKeyForService(service: ApiKeyService, key: string) {
   return validateTvdbApiKey(key)
 }
 
+function refreshStreamProviderConfig(): void {
+  const rdProviderUrls = getSetting('rdStreamProviderUrls') ?? ''
+  const torBoxProviderUrls = getSetting('torBoxStreamProviderUrls') ?? ''
+  const genericProviderUrls = getSetting('streamProviderUrls') ?? ''
+  config.streamProviderUrls = collectStreamProviderUrls(
+    rdProviderUrls,
+    torBoxProviderUrls,
+    genericProviderUrls,
+  )
+  config.stremioSearchProviderUrls = collectStreamProviderUrls(
+    rdProviderUrls,
+    torBoxProviderUrls,
+    genericProviderUrls,
+    config.streamProviderUrls.join('\n'),
+    config.sootioUrl,
+  )
+}
+
 function html(file: string) {
   return readFileSync(join(__dir, file), 'utf8')
     .replaceAll('__APP_VERSION_LABEL__', escapeHtml(APP_BUILD.label))
@@ -827,11 +845,7 @@ export async function uiRoutes(app: FastifyInstance) {
       const enabled = parseBooleanSetting(String(body.torBoxCleanupEnabled), true)
       setSetting('torBoxCleanupMode', enabled ? 'delete' : 'keep')
     }
-    config.streamProviderUrls = collectStreamProviderUrls(
-      getSetting('rdStreamProviderUrls') ?? '',
-      getSetting('torBoxStreamProviderUrls') ?? '',
-      getSetting('streamProviderUrls') ?? '',
-    )
+    refreshStreamProviderConfig()
     if (typeof body.englishStreamMode === 'string') {
       const mode = parseEnglishStreamMode(body.englishStreamMode)
       setSetting('englishStreamMode', mode)

--- a/src/ui/routes.ts
+++ b/src/ui/routes.ts
@@ -711,6 +711,7 @@ export async function uiRoutes(app: FastifyInstance) {
       preferredAudioLanguage: config.preferredAudioLanguage,
       englishStreamMode: config.englishStreamMode,
       streamRankingMode: config.streamRankingMode,
+      mediaSourceSelection: config.mediaSourceSelection,
       serverUrl:         config.serverUrl,
       traktClientId:     config.traktClientId,
       traktWatchlistMovies: config.traktWatchlistMovies,
@@ -839,6 +840,11 @@ export async function uiRoutes(app: FastifyInstance) {
       const mode = parseStreamRankingMode(body.streamRankingMode)
       setSetting('streamRankingMode', mode)
       config.streamRankingMode = mode
+    }
+    if (body.mediaSourceSelection != null) {
+      const enabled = parseBooleanSetting(String(body.mediaSourceSelection), false)
+      setSetting('mediaSourceSelection', enabled ? 'true' : 'false')
+      config.mediaSourceSelection = enabled
     }
     if (typeof body.preferredAudioLanguage === 'string') {
       const language = parseAudioLanguage(body.preferredAudioLanguage)

--- a/src/ui/routes.ts
+++ b/src/ui/routes.ts
@@ -22,7 +22,7 @@ import {
   getSessionCookie, clearSessionCookie, getTokenFromCookie,
 } from './auth.js'
 import { config } from '../config.js'
-import { collectStreamProviderUrls, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseEnglishStreamMode, parseMdblistLists, parseMovieReleaseMode, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists } from '../config.js'
+import { collectStreamProviderUrls, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseEnglishStreamMode, parseMdblistLists, parseMediaSourceLimit, parseMovieReleaseMode, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists } from '../config.js'
 import { fetchMovieByTmdbId, fetchMovieCollection, fetchShowByTmdbId, ensureShowSeasonsCached } from '../tmdb.js'
 import { cleanupRemovedTraktListSources, fetchTraktUserLists } from '../trakt.js'
 import { cleanupRemovedMdblistListSources, normalizeMdblistEntries } from '../mdblist.js'
@@ -712,6 +712,7 @@ export async function uiRoutes(app: FastifyInstance) {
       englishStreamMode: config.englishStreamMode,
       streamRankingMode: config.streamRankingMode,
       mediaSourceSelection: config.mediaSourceSelection,
+      mediaSourceLimit: config.mediaSourceLimit,
       serverUrl:         config.serverUrl,
       traktClientId:     config.traktClientId,
       traktWatchlistMovies: config.traktWatchlistMovies,
@@ -845,6 +846,11 @@ export async function uiRoutes(app: FastifyInstance) {
       const enabled = parseBooleanSetting(String(body.mediaSourceSelection), false)
       setSetting('mediaSourceSelection', enabled ? 'true' : 'false')
       config.mediaSourceSelection = enabled
+    }
+    if (body.mediaSourceLimit != null) {
+      const limit = parseMediaSourceLimit(String(body.mediaSourceLimit))
+      setSetting('mediaSourceLimit', String(limit))
+      config.mediaSourceLimit = limit
     }
     if (typeof body.preferredAudioLanguage === 'string') {
       const language = parseAudioLanguage(body.preferredAudioLanguage)

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -180,7 +180,7 @@
 
   <section class="section" id="users">
     <div class="section-title">Users</div>
-    <div class="field-note">Admin and user accounts are unrestricted. Kids are limited to kid-safe ratings.</div>
+    <div class="field-note">Set an optional ratings limit for User and Kids accounts. Admin accounts are always unrestricted.</div>
     <div class="user-table-wrap">
       <div class="user-table-scroll">
         <div id="userList"></div>
@@ -356,11 +356,15 @@
       </div>
       <div class="field">
         <label for="modalRole">Role</label>
-        <select id="modalRole">
+        <select id="modalRole" onchange="syncUserModalRatingLimit()">
           <option value="admin">Admin</option>
           <option value="user">User</option>
           <option value="kids">Kids</option>
         </select>
+      </div>
+      <div class="field">
+        <label for="modalMaxRating">Ratings Limit</label>
+        <select id="modalMaxRating" class="rating-limit-select"></select>
       </div>
     </div>
     <div class="modal-actions">
@@ -917,6 +921,40 @@
     ].map(([value, label]) => `<option value="${value}" ${value === selected ? 'selected' : ''}>${label}</option>`).join('')
   }
 
+  function ratingLimitOptions(selected) {
+    const value = selected == null || selected === '' ? 'unrestricted' : String(selected)
+    return [
+      ['unrestricted', 'No restrictions'],
+      ['0', 'Level 0: G, TV-Y, TV-G'],
+      ['1', 'Level 1: PG, TV-Y7, TV-Y7-FV, TV-PG'],
+      ['2', 'Level 2: PG-13, TV-14'],
+      ['3', 'Level 3: R, TV-MA'],
+      ['4', 'Level 4: NC-17'],
+    ].map(([optionValue, label]) => `<option value="${optionValue}" ${optionValue === value ? 'selected' : ''}>${label}</option>`).join('')
+  }
+
+  function defaultRatingLimitForRole(role) {
+    return role === 'kids' ? '1' : 'unrestricted'
+  }
+
+  function setUserModalRatingLimit(value) {
+    document.getElementById('modalMaxRating').innerHTML = ratingLimitOptions(value)
+    document.getElementById('modalMaxRating').value = value
+  }
+
+  function syncUserModalRatingLimit() {
+    const role = document.getElementById('modalRole').value
+    const rating = document.getElementById('modalMaxRating')
+    rating.disabled = role === 'admin'
+    if (role === 'admin') {
+      setUserModalRatingLimit('unrestricted')
+      return
+    }
+    if (userModalMode === 'create') {
+      setUserModalRatingLimit(defaultRatingLimitForRole(role))
+    }
+  }
+
   function renderUsers() {
     const el = document.getElementById('userList')
     if (!managedUsers.length) {
@@ -932,6 +970,7 @@
           <tr>
             <th>Username</th>
             <th>Role</th>
+            <th>Ratings Limit</th>
             <th>Password</th>
             <th>Actions</th>
           </tr>
@@ -946,6 +985,11 @@
               <td data-label="Role">
                 <select ${user.deleted ? 'disabled' : ''} onchange="updateUserRole('${user.id}', this.value)">
                   ${roleOptions(user.role)}
+                </select>
+              </td>
+              <td data-label="Ratings Limit">
+                <select class="rating-limit-select" ${user.deleted || user.role === 'admin' ? 'disabled' : ''} onchange="updateUserField('${user.id}', 'maxRating', this.value)">
+                  ${ratingLimitOptions(user.role === 'admin' ? 'unrestricted' : user.maxRating)}
                 </select>
               </td>
               <td data-label="Password">
@@ -978,13 +1022,16 @@
       id: tempId,
       username,
       role: document.getElementById('modalRole').value,
-      maxRating: 'unrestricted',
+      maxRating: document.getElementById('modalRole').value === 'admin'
+        ? 'unrestricted'
+        : document.getElementById('modalMaxRating').value,
       pendingPassword: password,
       isNew: true,
       deleted: false,
     })
     closeUserModal()
     renderUsers()
+    _markDirty()
     showOut('User queued. Click Save Settings to apply.', 'info')
   }
 
@@ -992,13 +1039,17 @@
     const user = managedUsers.find(u => u.id === id)
     if (!user) return
     user[key] = value
+    _markDirty()
   }
 
   function updateUserRole(id, value) {
     const user = managedUsers.find(u => u.id === id)
     if (!user) return
     user.role = value
+    if (value === 'admin') user.maxRating = 'unrestricted'
+    if (value === 'kids' && (!user.maxRating || user.maxRating === 'unrestricted')) user.maxRating = defaultRatingLimitForRole(value)
     renderUsers()
+    _markDirty()
   }
 
   function setUserPassword(id) {
@@ -1013,6 +1064,8 @@
     document.getElementById('modalPassword').value = ''
     document.getElementById('modalRole').value = user.role
     document.getElementById('modalRole').disabled = true
+    setUserModalRatingLimit(user.role === 'admin' ? 'unrestricted' : user.maxRating || defaultRatingLimitForRole(user.role))
+    document.getElementById('modalMaxRating').disabled = user.role === 'admin'
     document.getElementById('userModalConfirmBtn').textContent = 'Set Password'
     document.getElementById('userModalBackdrop').classList.add('open')
     document.addEventListener('keydown', onUserModalKey)
@@ -1024,6 +1077,7 @@
     if (!user) return
     user.deleted = !user.deleted
     renderUsers()
+    _markDirty()
   }
 
   function openNewUserModal() {
@@ -1036,6 +1090,8 @@
     document.getElementById('modalPassword').value = ''
     document.getElementById('modalRole').value = 'user'
     document.getElementById('modalRole').disabled = false
+    setUserModalRatingLimit(defaultRatingLimitForRole('user'))
+    document.getElementById('modalMaxRating').disabled = false
     document.getElementById('userModalConfirmBtn').textContent = 'Add User'
     document.getElementById('userModalBackdrop').classList.add('open')
     document.addEventListener('keydown', onUserModalKey)
@@ -1062,8 +1118,10 @@
       const user = managedUsers.find(u => u.id === userModalTargetId)
       if (!user) return
       user.pendingPassword = password
+      if (user.role !== 'admin') user.maxRating = document.getElementById('modalMaxRating').value
       closeUserModal()
       renderUsers()
+      _markDirty()
       showOut(`Password update queued for ${user.username}.`, 'info')
       return
     }
@@ -1319,12 +1377,14 @@
             username: user.username,
             password: user.pendingPassword,
             role: user.role,
+            maxRating: user.role === 'admin' ? 'unrestricted' : user.maxRating || 'unrestricted',
           }
         : {
             id: user.id,
             username: user.username,
             ...(user.pendingPassword ? { password: user.pendingPassword } : {}),
             role: user.role,
+            maxRating: user.role === 'admin' ? 'unrestricted' : user.maxRating || 'unrestricted',
           }
 
       const userRes = await fetch('/ui/users-data', {

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -106,12 +106,20 @@
       <div class="field-note">Use Provider order when your add-on already ranks streams correctly.</div>
     </div>
     <label class="check-item field" for="mediaSourceSelection">
-      <input id="mediaSourceSelection" type="checkbox">
+      <input id="mediaSourceSelection" type="checkbox" onchange="syncMediaSourceLimitVisibility()">
       <div class="check-meta">
         <div class="check-title">Media source selection</div>
-        <div class="check-slug">Shows cached stream options for episode playback. Movies continue using automatic playback.</div>
+        <div class="check-slug">Shows cached stream options for movie and episode playback.</div>
       </div>
     </label>
+    <div class="field" id="mediaSourceLimitField" hidden>
+      <label for="mediaSourceLimit">Sources Offered</label>
+      <select id="mediaSourceLimit">
+        <option value="10">10 sources</option>
+        <option value="5">5 sources</option>
+      </select>
+      <div class="field-note">Versions are ordered by estimated Mbps.</div>
+    </div>
   </section>
 
   <!-- Debrid -->
@@ -625,6 +633,11 @@
     el.textContent = msg
   }
 
+  function syncMediaSourceLimitVisibility() {
+    const enabled = document.getElementById('mediaSourceSelection').checked
+    document.getElementById('mediaSourceLimitField').hidden = !enabled
+  }
+
   function setSecretPlaceholder(id, hasStored, emptyPlaceholder) {
     const input = document.getElementById(id)
     input.value = ''
@@ -863,6 +876,8 @@
     document.getElementById('englishStreamMode').value = d.englishStreamMode || 'prefer'
     document.getElementById('streamRankingMode').value = d.streamRankingMode || 'fetcherr'
     document.getElementById('mediaSourceSelection').checked = d.mediaSourceSelection === true
+    document.getElementById('mediaSourceLimit').value = String(d.mediaSourceLimit === 5 ? 5 : 10)
+    syncMediaSourceLimitVisibility()
     setSecretPlaceholder('rdApiKey', hasStoredRdApiKey, 'Enter your Real-Debrid API key')
     setSecretPlaceholder('torBoxApiKey', hasStoredTorBoxApiKey, 'Enter your TorBox API key')
     setSecretPlaceholder('tmdbApiKey', hasStoredTmdbApiKey, 'Enter your TMDB API key')
@@ -1249,6 +1264,7 @@
       englishStreamMode: document.getElementById('englishStreamMode').value,
       streamRankingMode: document.getElementById('streamRankingMode').value,
       mediaSourceSelection: document.getElementById('mediaSourceSelection').checked,
+      mediaSourceLimit: document.getElementById('mediaSourceLimit').value,
       serverUrl:         document.getElementById('serverUrl').value,
       showAddDefaultMode: document.getElementById('showAddDefaultMode').value,
       movieReleaseMode: document.getElementById('movieReleaseMode').value,

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -105,6 +105,13 @@
       </select>
       <div class="field-note">Use Provider order when your add-on already ranks streams correctly.</div>
     </div>
+    <label class="check-item field" for="mediaSourceSelection">
+      <input id="mediaSourceSelection" type="checkbox">
+      <div class="check-meta">
+        <div class="check-title">Media source selection</div>
+        <div class="check-slug">Shows cached stream options for episode playback. Movies continue using automatic playback.</div>
+      </div>
+    </label>
   </section>
 
   <!-- Debrid -->
@@ -855,6 +862,7 @@
     document.getElementById('preferredAudioLanguage').value = d.preferredAudioLanguage || 'en'
     document.getElementById('englishStreamMode').value = d.englishStreamMode || 'prefer'
     document.getElementById('streamRankingMode').value = d.streamRankingMode || 'fetcherr'
+    document.getElementById('mediaSourceSelection').checked = d.mediaSourceSelection === true
     setSecretPlaceholder('rdApiKey', hasStoredRdApiKey, 'Enter your Real-Debrid API key')
     setSecretPlaceholder('torBoxApiKey', hasStoredTorBoxApiKey, 'Enter your TorBox API key')
     setSecretPlaceholder('tmdbApiKey', hasStoredTmdbApiKey, 'Enter your TMDB API key')
@@ -1240,6 +1248,7 @@
       preferredAudioLanguage: document.getElementById('preferredAudioLanguage').value,
       englishStreamMode: document.getElementById('englishStreamMode').value,
       streamRankingMode: document.getElementById('streamRankingMode').value,
+      mediaSourceSelection: document.getElementById('mediaSourceSelection').checked,
       serverUrl:         document.getElementById('serverUrl').value,
       showAddDefaultMode: document.getElementById('showAddDefaultMode').value,
       movieReleaseMode: document.getElementById('movieReleaseMode').value,

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -2051,7 +2051,7 @@ label {
 
 .user-table {
   width: 100%;
-  min-width: 820px;
+  min-width: 980px;
   border-collapse: collapse;
 }
 
@@ -2093,6 +2093,11 @@ label {
 .user-table select {
   min-width: 0;
   margin: 0;
+}
+
+.user-table .rating-limit-select {
+  width: min(100%, 10rem);
+  text-overflow: ellipsis;
 }
 
 .username-cell {
@@ -2543,6 +2548,7 @@ body.dashboard-page {
     grid-template-columns: minmax(0, 1fr) minmax(104px, .45fr);
     grid-template-areas:
       "identity role"
+      "limit limit"
       "password action";
     gap: 10px;
     padding: 12px;
@@ -2563,8 +2569,9 @@ body.dashboard-page {
 
   .settings-page .user-table tbody td:nth-child(1) { grid-area: identity; }
   .settings-page .user-table tbody td:nth-child(2) { grid-area: role; }
-  .settings-page .user-table tbody td:nth-child(3) { grid-area: password; }
-  .settings-page .user-table tbody td:nth-child(4) { grid-area: action; }
+  .settings-page .user-table tbody td:nth-child(3) { grid-area: limit; }
+  .settings-page .user-table tbody td:nth-child(4) { grid-area: password; }
+  .settings-page .user-table tbody td:nth-child(5) { grid-area: action; }
 
   .settings-page .user-table tbody td::before {
     display: none;
@@ -2887,6 +2894,7 @@ body.dashboard-page {
     grid-template-columns: minmax(0, 1fr) minmax(104px, .45fr);
     grid-template-areas:
       "identity role"
+      "limit limit"
       "password action";
     gap: 10px;
     padding: 12px;
@@ -2907,8 +2915,9 @@ body.dashboard-page {
 
   .user-table tbody td:nth-child(1) { grid-area: identity; }
   .user-table tbody td:nth-child(2) { grid-area: role; }
-  .user-table tbody td:nth-child(3) { grid-area: password; }
-  .user-table tbody td:nth-child(4) { grid-area: action; }
+  .user-table tbody td:nth-child(3) { grid-area: limit; }
+  .user-table tbody td:nth-child(4) { grid-area: password; }
+  .user-table tbody td:nth-child(5) { grid-area: action; }
 
   .user-table tbody td::before {
     display: none;


### PR DESCRIPTION
## Summary
- Add Stremio search streaming support, optional media source selection, and playback source handling including Easynews redirect fixes.
- Harden playback and Stremio proxy paths with authenticated stream context, URL validation, cache caps, and refreshed provider settings.
- Add per-user ratings limits with admin/unrestricted bypass behavior, Settings UI controls, and TMDB/TVDB rating fallback for restricted metadata.
- Update documentation for search results, Infuse source selection, direct URL support, and selected media source fallback behavior.

## Validation
- `npm run build`
