### PR TITLE
Add Infuse search-only Jellyfin endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,16 @@ Enable **Media source selection** in Settings to offer source choices. By defaul
 
 ## Connecting Infuse
 
-Add Fetcherr as a Jellyfin server in Infuse with your server URL and a Fetcherr account. Enable **Library Mode**, **Auto Scan**, and **Install InfuseSync Plugin**.
+Add Fetcherr as a Jellyfin server in Infuse with your server URL and a Fetcherr account. Enable **Library Mode** and **Auto Scan** for the normal library connection.
+
+### Infuse Search
+
+Fetcherr can also be added to Infuse a second time for broad search. Use the same Fetcherr server and set of accounts, set the connection **Path** to `/search`, and do not enable Library Mode. Broad Stremio search must be enabled globally in Fetcherr Settings and for the Fetcherr user account.
+
+Search results can always include synced Fetcherr library items. When Stremio search is enabled, results can also include Cinemeta, Trakt, or configured add-on catalogs such as AIOStreams. Fetcherr uses TMDB metadata for local catalog entries and search-result details.
+
+> [!NOTE]
+> The `/search` endpoint presents a separate Jellyfin server identity with no library folders or library items. Infuse can use that second connection for search results, while the normal connection remains available for Library Mode browsing and scanning.
 
 ## Connecting VidHub
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetcherr",
-  "version": "1.7.0",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetcherr",
-      "version": "1.7.0",
+      "version": "1.7.2",
       "dependencies": {
         "@viren070/parse-torrent-title": "^0.7.6",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcherr",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Jellyfin-compatible bridge for Infuse with Trakt library sync and Real-Debrid or TorBox stream resolution.",
   "type": "module",
   "scripts": {

--- a/src/db.ts
+++ b/src/db.ts
@@ -84,6 +84,7 @@ export interface AppUser {
   passwordHash: string
   role: AppUserRole
   maxRating: string
+  searchEnabled: boolean
   createdAt: string
   updatedAt: string
 }
@@ -300,6 +301,7 @@ CREATE TABLE IF NOT EXISTS app_users (
   password_hash TEXT NOT NULL DEFAULT '',
   role          TEXT NOT NULL CHECK (role IN ('admin', 'user', 'kids')),
   max_rating    TEXT NOT NULL DEFAULT 'unrestricted',
+  search_enabled INTEGER NOT NULL DEFAULT 1,
   created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
   updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
 );
@@ -491,6 +493,7 @@ export function getDb(): Database.Database {
     )`) } catch { /* already exists */ }
     try { _db.exec(`CREATE INDEX IF NOT EXISTS torbox_cleanup_jobs_delete_at ON torbox_cleanup_jobs(delete_at)`) } catch { /* already exists */ }
     migrateAppUserRoles(_db)
+    migrateAppUserSearchEnabled(_db)
     migrateLegacyUserData(_db)
   }
   return _db
@@ -535,6 +538,10 @@ function effectiveMaxRatingForRole(role: AppUserRole, maxRating: string): MaxRat
   return normalizeMaxRating(maxRating)
 }
 
+function defaultSearchEnabledForRole(role: AppUserRole): boolean {
+  return role !== 'kids'
+}
+
 function row2appUser(r: Record<string, unknown>): AppUser {
   const role = normalizeUserRole(r.role as string)
   return {
@@ -543,6 +550,7 @@ function row2appUser(r: Record<string, unknown>): AppUser {
     passwordHash: (r.password_hash as string) ?? '',
     role,
     maxRating: effectiveMaxRatingForRole(role, (r.max_rating as string) ?? 'unrestricted'),
+    searchEnabled: r.search_enabled == null ? defaultSearchEnabledForRole(role) : Number(r.search_enabled) !== 0,
     createdAt: (r.created_at as string) ?? '',
     updatedAt: (r.updated_at as string) ?? '',
   }
@@ -626,15 +634,25 @@ function migrateAppUserRoles(db: Database.Database): void {
         password_hash TEXT NOT NULL DEFAULT '',
         role          TEXT NOT NULL CHECK (role IN ('admin', 'user', 'kids')),
         max_rating    TEXT NOT NULL DEFAULT 'unrestricted',
+        search_enabled INTEGER NOT NULL DEFAULT 1,
         created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
         updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
       );
-      INSERT INTO app_users_new (id, username, password_hash, role, max_rating, created_at, updated_at)
-      SELECT id, username, password_hash, role, max_rating, created_at, updated_at
+      INSERT INTO app_users_new (id, username, password_hash, role, max_rating, search_enabled, created_at, updated_at)
+      SELECT id, username, password_hash, role, max_rating, CASE role WHEN 'kids' THEN 0 ELSE 1 END, created_at, updated_at
       FROM app_users;
       DROP TABLE app_users;
       ALTER TABLE app_users_new RENAME TO app_users;
     `)
+  })()
+}
+
+function migrateAppUserSearchEnabled(db: Database.Database): void {
+  const columns = db.prepare(`PRAGMA table_info(app_users)`).all() as Array<{ name: string }>
+  if (columns.some(column => column.name === 'search_enabled')) return
+  db.transaction(() => {
+    db.exec(`ALTER TABLE app_users ADD COLUMN search_enabled INTEGER NOT NULL DEFAULT 1`)
+    db.prepare(`UPDATE app_users SET search_enabled = 0 WHERE role = 'kids'`).run()
   })()
 }
 
@@ -1545,28 +1563,35 @@ export function verifyUserCredentials(username: string, password: string): AppUs
   return verifyPasswordHash(password, user.passwordHash) ? user : null
 }
 
-export function createUser(username: string, password: string, role: AppUserRole, maxRating: string): AppUser {
+export function createUser(
+  username: string,
+  password: string,
+  role: AppUserRole,
+  maxRating: string,
+  searchEnabled = defaultSearchEnabledForRole(role),
+): AppUser {
   const normalized = normalizeUsername(username)
   if (!normalized) throw new Error('Username is required')
   if (!password.trim()) throw new Error('Password is required')
   const id = role === 'admin' && countUsers() === 0 ? DEFAULT_ADMIN_USER_ID : randomGuidLikeId()
   const effectiveMaxRating = effectiveMaxRatingForRole(role, maxRating)
   getDb().prepare(`
-    INSERT INTO app_users (id, username, password_hash, role, max_rating, updated_at)
-    VALUES (?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
-  `).run(id, normalized, hashPassword(password), role, effectiveMaxRating)
+    INSERT INTO app_users (id, username, password_hash, role, max_rating, search_enabled, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+  `).run(id, normalized, hashPassword(password), role, effectiveMaxRating, searchEnabled ? 1 : 0)
   return getUserById(id)!
 }
 
 export function updateUser(
   userId: string,
-  updates: { username?: string; password?: string; role?: AppUserRole; maxRating?: string },
+  updates: { username?: string; password?: string; role?: AppUserRole; maxRating?: string; searchEnabled?: boolean },
 ): AppUser {
   const existing = getUserById(userId)
   if (!existing) throw new Error('User not found')
   const username = updates.username != null ? normalizeUsername(updates.username) : existing.username
   const role = updates.role ?? existing.role
   const maxRating = effectiveMaxRatingForRole(role, updates.maxRating != null ? updates.maxRating : existing.maxRating)
+  const searchEnabled = updates.searchEnabled ?? existing.searchEnabled
   const passwordHash = updates.password && updates.password.trim()
     ? hashPassword(updates.password)
     : existing.passwordHash
@@ -1577,9 +1602,9 @@ export function updateUser(
   }
   getDb().prepare(`
     UPDATE app_users
-    SET username = ?, password_hash = ?, role = ?, max_rating = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
+    SET username = ?, password_hash = ?, role = ?, max_rating = ?, search_enabled = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
     WHERE id = ?
-  `).run(username, passwordHash, role, maxRating, userId)
+  `).run(username, passwordHash, role, maxRating, searchEnabled ? 1 : 0, userId)
   return getUserById(userId)!
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1891,6 +1891,7 @@ app.get('/play/:imdbId/:season/:episode', async (req, reply) => {
 
 await app.register(jellyfinRoutes, { prewarmPlayback, registerPlaybackItem, registerPlaybackClient, touchPlaybackItem, stopPlaybackItem, buildPlaybackMediaSources })
 await app.register(jellyfinRoutes, { prefix: '/emby', prewarmPlayback, registerPlaybackItem, registerPlaybackClient, touchPlaybackItem, stopPlaybackItem, buildPlaybackMediaSources })
+await app.register(jellyfinRoutes, { prefix: '/search', searchOnly: true, prewarmPlayback, registerPlaybackItem, registerPlaybackClient, touchPlaybackItem, stopPlaybackItem, buildPlaybackMediaSources })
 await app.register(uiRoutes)
 
 // ── Trakt auth ────────────────────────────────────────────────────────────────

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -42,7 +42,10 @@ import { searchTraktMetas } from '../trakt.js'
 const MOVIES_FOLDER_ID = 'a0000000-0000-4000-8000-000000000001'
 const SHOWS_FOLDER_ID  = 'a0000000-0000-4000-8000-000000000002'
 const COLLECTIONS_FOLDER_ID = 'a0000000-0000-4000-8007-000000000001'
+const SEARCH_DISABLED_ITEM_ID = 'a0000000-0000-4000-800a-000000000001'
+const SEARCH_DISABLED_RUNTIME_TICKS = 60 * 10_000_000
 const SERVER_GUID      = 'a0000000-0000-0000-0000-000000000001'
+const SEARCH_SERVER_GUID = 'a0000000-0000-0000-0000-00000000f001'
 // Keep old name as alias so existing code still compiles
 const FOLDER_ID = MOVIES_FOLDER_ID
 
@@ -71,6 +74,7 @@ const stremioSeasonCache = new Map<string, { series: StremioMeta; seasonNumber: 
 const stremioEpisodeCache = new Map<string, { series: StremioMeta; episode: StremioMeta; expiresAt: number }>()
 const stremioRatingCache = new Map<string, { rating: string; expiresAt: number }>()
 type JellyfinRouteOptions = {
+  searchOnly?: boolean
   prewarmPlayback?: (playPath: string, label: string) => void
   registerPlaybackItem?: (itemId: string, playPath: string) => void
   registerPlaybackClient?: (playPath: string, clientName: string) => void
@@ -1559,6 +1563,65 @@ async function stremioRatingForVisibleMeta(user: AppUser, meta: StremioMeta, med
   return stremioOfficialRating(meta, mediaType)
 }
 
+function externalSearchEnabledForUser(user: AppUser): boolean {
+  return config.stremioSearchEnabled && user.searchEnabled
+}
+
+function searchDisabledItem(includeTypes: string) {
+  const type = includeTypes.includes('series') && !includeTypes.includes('movie') ? 'Series' : 'Movie'
+  const isSeries = type === 'Series'
+  return {
+    Id:                 SEARCH_DISABLED_ITEM_ID,
+    ServerId:           SERVER_GUID,
+    Name:               'Fetcherr Search Disabled',
+    SortName:           'fetcherr search disabled',
+    Type:               type,
+    MediaType:          'Video',
+    VideoType:          'VideoFile',
+    LocationType:       'FileSystem',
+    PlayAccess:         'Full',
+    IsPlayable:         true,
+    CanDelete:          false,
+    CanDownload:        false,
+    Overview:           'Search must be enabled globally in Settings and for this Fetcherr user.',
+    IsFolder:           isSeries,
+    ChildCount:         isSeries ? 0 : undefined,
+    RecursiveItemCount: isSeries ? 0 : undefined,
+    RunTimeTicks:       SEARCH_DISABLED_RUNTIME_TICKS,
+    Path:               '/fetcherr/search-disabled.mkv',
+    ImageTags:          {},
+    BackdropImageTags:  [],
+    ProviderIds:        {},
+    UserData:           userDataForItem(SEARCH_DISABLED_ITEM_ID, { played: false, playCount: 0, positionTicks: 0, lastPlayedDate: '' }),
+  }
+}
+
+function searchDisabledMediaSource(origin: string) {
+  return defaultPlaybackMediaSource(
+    SEARCH_DISABLED_ITEM_ID,
+    'Fetcherr Search Disabled',
+    `${origin}/Videos/${SEARCH_DISABLED_ITEM_ID}/stream?PlaySessionId=fetcherr-${SEARCH_DISABLED_ITEM_ID}&MediaSourceId=${SEARCH_DISABLED_ITEM_ID}`,
+    SEARCH_DISABLED_RUNTIME_TICKS,
+  )
+}
+
+function searchDisabledPlaybackInfo(origin: string) {
+  const mediaSources = [searchDisabledMediaSource(origin)]
+  return {
+    MediaSources: mediaSources,
+    AlternateMediaSources: mediaSources,
+    PlaySessionId: `fetcherr-${SEARCH_DISABLED_ITEM_ID}`,
+  }
+}
+
+function searchDisabledResponse(includeTypes: string, limit: number, offset: number) {
+  return {
+    Items: offset > 0 || limit <= 0 ? [] : [searchDisabledItem(includeTypes)],
+    TotalRecordCount: 1,
+    StartIndex: offset,
+  }
+}
+
 async function buildSearchResultItems(
   searchTerm: string,
   includeTypes: string,
@@ -1575,19 +1638,20 @@ async function buildSearchResultItems(
     ...(wantShows ? ['series' as const] : []),
   ]
 
-  const rawStremioMetas = stremioTypes.length && config.stremioSearchEnabled
-    ? await (config.stremioSearchSource === 'trakt'
-        ? searchTraktMetas(searchTerm, stremioTypes).catch(() => [])
-        : searchStremioMetas(searchTerm, stremioTypes).catch(() => []))
-    : []
-  const stremioMetas = rawStremioMetas.filter(meta => !isStremioErrorMeta(meta))
-
   const localMovies = wantMovies
     ? filterMoviesForUser(user, listMovies({ search: searchTerm, sortBy, sortOrder, limit: 10_000, offset: 0, userId: user.id, ...API_LIBRARY_FILTER }))
     : []
   const localShows = wantShows
     ? filterShowsForUser(user, listShows({ search: searchTerm, sortBy, sortOrder, limit: 10_000, offset: 0, userId: user.id, ...API_LIBRARY_FILTER }))
     : []
+  const externalSearchEnabled = externalSearchEnabledForUser(user)
+
+  const rawStremioMetas = externalSearchEnabled && stremioTypes.length
+    ? await (config.stremioSearchSource === 'trakt'
+        ? searchTraktMetas(searchTerm, stremioTypes).catch(() => [])
+        : searchStremioMetas(searchTerm, stremioTypes).catch(() => []))
+    : []
+  const stremioMetas = rawStremioMetas.filter(meta => !isStremioErrorMeta(meta))
 
   const localMovieIds = new Set(localMovies.map(movie => movie.tmdbId))
   const localShowIds = new Set(localShows.map(show => show.tmdbId))
@@ -1622,6 +1686,10 @@ async function buildSearchResultItems(
     ...localShows.map(show => showToSeriesItem(show, user.id)),
     ...stremioSearchItems,
   ]
+
+  if (!combined.length && !externalSearchEnabled) {
+    return searchDisabledResponse(includeTypes, limit, offset)
+  }
 
   return {
     Items: pagedItems(combined, offset, limit),
@@ -1821,12 +1889,12 @@ export function resolveJellyfinUser(headers: Record<string, string | string[] | 
   return getUserById(record.userId)
 }
 
-function jellyfinUser(user: AppUser) {
+function jellyfinUser(user: AppUser, serverId = SERVER_GUID, serverName = config.serverName) {
   return {
     Name:                  user.username,
     Id:                    user.id,
-    ServerId:              SERVER_GUID,
-    ServerName:            config.serverName,
+    ServerId:              serverId,
+    ServerName:            serverName,
     PrimaryImageTag:       null,
     HasPassword:           true,
     HasConfiguredPassword: true,
@@ -1842,17 +1910,18 @@ function jellyfinUser(user: AppUser) {
   }
 }
 
-function jellyfinSessionInfo(user: AppUser, accessToken: string) {
+function jellyfinSessionInfo(user: AppUser, accessToken: string, serverId = SERVER_GUID, searchOnly = false) {
   const now = new Date().toISOString()
+  const deviceSuffix = searchOnly ? '-search' : ''
   return {
     Id:              `${user.id}:${accessToken.slice(0, 12)}`,
     UserId:          user.id,
     UserName:        user.username,
     Client:          'Fetcherr',
-    DeviceName:      'Fetcherr',
+    DeviceName:      searchOnly ? 'Fetcherr Search' : 'Fetcherr',
     DeviceType:      'Browser',
-    DeviceId:        `fetcherr-${user.id}`,
-    AppName:         'Fetcherr',
+    DeviceId:        `fetcherr-${user.id}${deviceSuffix}`,
+    AppName:         searchOnly ? 'Fetcherr Search' : 'Fetcherr',
     AppVersion:      '1.0.0',
     ApplicationVersion: '1.0.0',
     PlayableMediaTypes: ['Video'],
@@ -1863,7 +1932,7 @@ function jellyfinSessionInfo(user: AppUser, accessToken: string) {
     IsActive:        true,
     LastActivityDate: now,
     LastPlaybackCheckIn: now,
-    ServerId:        SERVER_GUID,
+    ServerId:        serverId,
     UserPrimaryImageTag: null,
     AdditionalUsers: [],
     NowPlayingQueue: [],
@@ -1937,6 +2006,30 @@ function signedPlaybackUrlForMediaSource(origin: string, playPath: string, media
 // ── Route registration ────────────────────────────────────────────────────────
 
 export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOptions = {}) {
+  const routeServerId = opts.searchOnly ? SEARCH_SERVER_GUID : SERVER_GUID
+  const routeServerName = () => opts.searchOnly ? `${config.serverName} Search` : config.serverName
+  const emptyItems = (startIndex = 0) => ({ Items: [], TotalRecordCount: 0, StartIndex: startIndex })
+
+  function routeServerPayload<T>(payload: T): T {
+    if (!opts.searchOnly || payload == null || typeof payload !== 'object') return payload
+    if (payload instanceof Uint8Array || payload instanceof ArrayBuffer) return payload
+    if (Array.isArray(payload)) return payload.map(item => routeServerPayload(item)) as T
+    const output: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+      if (key === 'ServerId' && value === SERVER_GUID) {
+        output[key] = routeServerId
+      } else if (key === 'ServerName' && value === config.serverName) {
+        output[key] = routeServerName()
+      } else {
+        output[key] = routeServerPayload(value)
+      }
+    }
+    return output as T
+  }
+
+  if (opts.searchOnly) {
+    app.addHook('preSerialization', async (_req, _reply, payload) => routeServerPayload(payload))
+  }
 
   function requireJellyfinUser(
     headers: Record<string, string | string[] | undefined>,
@@ -1960,8 +2053,8 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
   function systemInfo() {
     return {
-      ServerName:             config.serverName,
-      Id:                     SERVER_GUID,
+      ServerName:             routeServerName(),
+      Id:                     routeServerId,
       Version:                '10.11.0',
       ProductName:            'Jellyfin Server',
       OperatingSystem:        'Linux',
@@ -2022,29 +2115,29 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const accessToken = createJellyfinToken(user.id)
     return {
       AccessToken: accessToken,
-      ServerId:    SERVER_GUID,
-      SessionInfo: jellyfinSessionInfo(user, accessToken),
-      User:        jellyfinUser(user),
+      ServerId:    routeServerId,
+      SessionInfo: jellyfinSessionInfo(user, accessToken, routeServerId, Boolean(opts.searchOnly)),
+      User:        jellyfinUser(user, routeServerId, routeServerName()),
     }
   })
 
   // Public users — used by Jellyfin clients during login and server discovery
-  app.get('/Users/Public', async () => listUsers().map(jellyfinUser))
+  app.get('/Users/Public', async () => listUsers().map(user => jellyfinUser(user, routeServerId, routeServerName())))
 
   // User profile
   app.get('/Users/:id', async (req, reply) => {
     const user = requireJellyfinUser(req.headers, reply)
     if (!user) return
-    return jellyfinUser(user)
+    return jellyfinUser(user, routeServerId, routeServerName())
   })
   app.get('/Users/Me',  async (req, reply) => {
     const user = requireJellyfinUser(req.headers, reply)
     if (!user) return
-    return jellyfinUser(user)
+    return jellyfinUser(user, routeServerId, routeServerName())
   })
 
   // Library sections
-  app.get('/Library/VirtualFolders', async () => ([
+  app.get('/Library/VirtualFolders', async () => opts.searchOnly ? [] : ([
     { Name: 'Movies', CollectionType: 'movies', ItemId: MOVIES_FOLDER_ID, Locations: ['/movies'] },
     { Name: 'Shows',  CollectionType: 'tvshows', ItemId: SHOWS_FOLDER_ID,  Locations: ['/shows'] },
     ...(config.traktCollections
@@ -2062,7 +2155,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
   app.get('/Library/SelectableMediaFolders', async () => null)
 
   // Grouping options
-  app.get('/Users/:id/GroupingOptions', async () => ([
+  app.get('/Users/:id/GroupingOptions', async () => opts.searchOnly ? [] : ([
     { Name: 'Movies', Id: MOVIES_FOLDER_ID, Type: 'movies' },
     { Name: 'Shows',  Id: SHOWS_FOLDER_ID,  Type: 'tvshows' },
     ...(config.traktCollections ? [{ Name: 'Collections', Id: COLLECTIONS_FOLDER_ID, Type: 'boxsets' }] : []),
@@ -2074,7 +2167,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       return { Name: nameForMdblistUrl(entry.url), Id: mdblistFolderIdFromPath(p), Type: 'boxsets' }
     }) : []),
   ]))
-  app.get('/UserViews/GroupingOptions', async () => ([
+  app.get('/UserViews/GroupingOptions', async () => opts.searchOnly ? [] : ([
     { Name: 'Movies', Id: MOVIES_FOLDER_ID, Type: 'movies' },
     { Name: 'Shows',  Id: SHOWS_FOLDER_ID,  Type: 'tvshows' },
     ...(config.traktCollections ? [{ Name: 'Collections', Id: COLLECTIONS_FOLDER_ID, Type: 'boxsets' }] : []),
@@ -2089,6 +2182,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
   // Views — library sections
   function viewItemsResponse(user: AppUser) {
+    if (opts.searchOnly) return emptyItems()
     const moviesCount = filterMoviesForUser(user, listMovies({ limit: 10_000, offset: 0, userId: user.id, ...API_LIBRARY_FILTER })).length
     const showsCount = filterShowsForUser(user, listShows({ limit: 10_000, offset: 0, userId: user.id, ...API_LIBRARY_FILTER })).length
     const items = [
@@ -2158,8 +2252,13 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const limit           = q.limit ? parseInt(q.limit) : 10_000
     const offset          = parseInt(q.startindex ?? '0')
 
+    if (opts.searchOnly && SearchTerm) {
+      return buildSearchResultItems(SearchTerm, includeTypes, SortBy, SortOrder, limit, offset, user)
+    }
+
     // ── Shows folder ───────────────────────────────────────────────────────────
     if (ParentId === SHOWS_FOLDER_ID) {
+      if (opts.searchOnly) return emptyItems(offset)
       // Infuse scans the library with three separate recursive queries:
       // includeItemTypes=Season  → flat list of all seasons across all shows
       // includeItemTypes=Episode → flat list of all aired episodes across all shows
@@ -2264,6 +2363,8 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
         : []
       return { Items: episodes.map(e => episodeToItem(e, show, user.id)), TotalRecordCount: episodes.length, StartIndex: offset }
     }
+
+    if (opts.searchOnly) return emptyItems(offset)
 
     const mdblistUrl = ParentId && config.mdblistFolders ? idToMdblistListUrl(ParentId) : null
     if (mdblistUrl) {
@@ -2425,6 +2526,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     for (const [k, v] of Object.entries(rawQuery)) q[k.toLowerCase()] = v
     const limit = parseInt(q.limit ?? '16', 10)
     const offset = parseInt(q.startindex ?? '0', 10)
+    if (opts.searchOnly) return emptyItems(offset)
     const seriesTmdbId = q.seriesid ? idToShowTmdb(q.seriesid) : null
     const allNextUp = await withReadCache(`nextup:${user.id}`, async () => {
       const playedIds = getAllPlayedItemIds(user.id)
@@ -2465,6 +2567,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     for (const [k, v] of Object.entries(req.query)) q[k.toLowerCase()] = v
     const limit = q.limit ? parseInt(q.limit, 10) : 50
     const offset = q.startindex ? parseInt(q.startindex, 10) : 0
+    if (opts.searchOnly) return emptyItems(offset)
     return withReadCache(`resume:${user.id}:${offset}:${limit}`, async () => {
       const ids = listResumeItemIds(limit, offset, user.id)
       const items = []
@@ -2496,6 +2599,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     for (const [k, v] of Object.entries(rawQuery)) q[k.toLowerCase()] = v
     const lim      = parseInt(q.limit ?? '16')
     const parentId = q.parentid
+    if (opts.searchOnly) return []
 
     if (parentId === SHOWS_FOLDER_ID) {
       return filterShowsForUser(user, listShows({ sortBy: 'popularity', sortOrder: 'DESC', limit: lim, userId: user.id, ...API_LIBRARY_FILTER })).map(show => showToSeriesItem(show, user.id))
@@ -2543,6 +2647,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       runtimeTicks: number
     },
   ) {
+    if (!config.mediaSourceSelection) return item
     return addDetailMediaSources(item, headers, {
       itemId: input.itemId,
       sourceId: input.sourceId,
@@ -2563,6 +2668,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       runtimeTicks: number
     },
   ) {
+    if (!config.mediaSourceSelection) return item
     return addDetailMediaSources(item, headers, {
       itemId: input.itemId,
       sourceId: input.sourceId,
@@ -2580,6 +2686,9 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
   ) {
     const currentUser = user === undefined ? fallbackUser() : user
     if (!currentUser) return reply.code(401).send({ error: 'Unauthorized' })
+    if (id === SEARCH_DISABLED_ITEM_ID) {
+      return searchDisabledItem('')
+    }
     // Collection folders
     if (id === MOVIES_FOLDER_ID) {
       const n = filterMoviesForUser(currentUser, listMovies({ limit: 10_000, offset: 0, userId: currentUser.id, ...API_LIBRARY_FILTER })).length
@@ -2616,6 +2725,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     if (stremioEpisode) {
       if (!await canUserAccessStremioMeta(currentUser, stremioEpisode.series, 'series')) return reply.code(404).send({ error: 'Not found' })
       const item = stremioEpisodeToItem(stremioEpisode.series, stremioEpisode.episode) as Record<string, unknown>
+      if (!config.mediaSourceSelection) return item
       const { series, episode } = stremioEpisode
       const externalId = episode.id || `${series.id}:${stremioEpisodeSeasonNumber(episode)}:${stremioEpisodeNumber(episode)}`
       const playPath = `/play/stremio/series/${encodeURIComponent(externalId)}`
@@ -2671,7 +2781,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       if (!ep) return reply.code(404).send({ error: 'Not found' })
       if (!isEpisodeVisibleToLibrary(ep)) return reply.code(404).send({ error: 'Not found' })
       const item = episodeToItem(ep, show, currentUser.id) as Record<string, unknown>
-      if (!show.imdbId) return item
+      if (!config.mediaSourceSelection || !show.imdbId) return item
       const playPath = `/play/${show.imdbId}/${ep.seasonNumber}/${ep.episodeNumber}`
       return addDetailMediaSources(item, headers, {
         itemId: id,
@@ -2767,6 +2877,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const user = requestUser(req.headers)
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
     const { seriesId } = req.params as { seriesId: string }
+    if (seriesId === SEARCH_DISABLED_ITEM_ID) return { Items: [], TotalRecordCount: 0, StartIndex: 0 }
     const stremioSeries = idToStremioSearchMeta(seriesId)
     if (stremioSeries?.mediaType === 'series') {
       if (!await canUserAccessStremioMeta(user, stremioSeries.meta, 'series')) {
@@ -2801,6 +2912,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const user = requestUser(req.headers)
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
     const { seriesId } = req.params as { seriesId: string }
+    if (seriesId === SEARCH_DISABLED_ITEM_ID) return { Items: [], TotalRecordCount: 0, StartIndex: 0 }
     const rawQ = (req as never as { query: Record<string, string | string[] | undefined> }).query
     const q: Record<string, string> = {}
     for (const [k, v] of Object.entries(rawQ)) q[k.toLowerCase()] = queryValue(v)
@@ -3122,6 +3234,9 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     const user = requestUser(req.headers)
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
     const { id } = req.params
+    if (id === SEARCH_DISABLED_ITEM_ID) {
+      return searchDisabledPlaybackInfo(buildPlaybackOrigin(req.headers))
+    }
 
     const stremioEpisode = idToStremioEpisode(id)
     if (stremioEpisode) {
@@ -3320,6 +3435,9 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
 
     const origin = buildPlaybackOrigin(req.headers as Record<string, string | undefined>)
+    if (id === SEARCH_DISABLED_ITEM_ID) {
+      return reply.code(409).send({ error: 'Search disabled', message: 'Fetcherr Search Disabled' })
+    }
 
     const stremioEpisode = idToStremioEpisode(id)
     if (stremioEpisode) {

--- a/src/ui/routes.ts
+++ b/src/ui/routes.ts
@@ -758,6 +758,7 @@ export async function uiRoutes(app: FastifyInstance) {
         username: user.username,
         role: user.role,
         maxRating: user.maxRating,
+        searchEnabled: user.searchEnabled,
       })),
     }
   })
@@ -971,6 +972,7 @@ export async function uiRoutes(app: FastifyInstance) {
       password?: string
       role?: string
       maxRating?: string
+      searchEnabled?: boolean
       action?: string
     }
     const role = body.role != null
@@ -987,11 +989,12 @@ export async function uiRoutes(app: FastifyInstance) {
           password: body.password,
           role,
           maxRating: body.maxRating,
+          searchEnabled: body.searchEnabled,
         })
-        return { ok: true, user: { id: user.id, username: user.username, role: user.role, maxRating: user.maxRating } }
+        return { ok: true, user: { id: user.id, username: user.username, role: user.role, maxRating: user.maxRating, searchEnabled: user.searchEnabled } }
       }
-      const user = createUser(body.username ?? '', body.password ?? '', role ?? 'user', body.maxRating ?? 'unrestricted')
-      return { ok: true, user: { id: user.id, username: user.username, role: user.role, maxRating: user.maxRating } }
+      const user = createUser(body.username ?? '', body.password ?? '', role ?? 'user', body.maxRating ?? 'unrestricted', body.searchEnabled)
+      return { ok: true, user: { id: user.id, username: user.username, role: user.role, maxRating: user.maxRating, searchEnabled: user.searchEnabled } }
     } catch (err) {
       return reply.code(400).send({ error: String(err instanceof Error ? err.message : err) })
     }

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -124,7 +124,7 @@
       <input id="stremioSearchEnabled" type="checkbox" onchange="syncStremioSearchSourceVisibility()">
       <div class="check-meta">
         <div class="check-title">Stremio search</div>
-        <div class="check-slug">Include add-on results when searching from Infuse or VidHub.</div>
+        <div class="check-slug">Include external Stremio, Trakt, or add-on results for users who also have Stremio Search enabled below.</div>
       </div>
     </label>
     <div class="field" id="stremioSearchSourceField" hidden>
@@ -661,6 +661,7 @@
   function syncStremioSearchSourceVisibility() {
     const enabled = document.getElementById('stremioSearchEnabled').checked
     document.getElementById('stremioSearchSourceField').hidden = !enabled
+    renderUsers()
   }
 
   function setSecretPlaceholder(id, hasStored, emptyPlaceholder) {
@@ -961,6 +962,10 @@
     return role === 'kids' ? '1' : 'unrestricted'
   }
 
+  function defaultSearchEnabledForRole(role) {
+    return role !== 'kids'
+  }
+
   function setUserModalRatingLimit(value) {
     document.getElementById('modalMaxRating').innerHTML = ratingLimitOptions(value)
     document.getElementById('modalMaxRating').value = value
@@ -988,6 +993,7 @@
       </div>`
       return
     }
+    const stremioSearchGlobalEnabled = document.getElementById('stremioSearchEnabled').checked
     el.innerHTML = `
       <table class="user-table">
         <thead>
@@ -995,6 +1001,7 @@
             <th>Username</th>
             <th>Role</th>
             <th>Ratings Limit</th>
+            <th>Stremio Search</th>
             <th>Password</th>
             <th>Actions</th>
           </tr>
@@ -1007,7 +1014,7 @@
                 <div class="user-id-cell">${user.isNew ? 'New user' : escapeHtml(user.id)}</div>
               </td>
               <td data-label="Role">
-                <select ${user.deleted ? 'disabled' : ''} onchange="updateUserRole('${user.id}', this.value)">
+                <select class="role-select" ${user.deleted ? 'disabled' : ''} onchange="updateUserRole('${user.id}', this.value)">
                   ${roleOptions(user.role)}
                 </select>
               </td>
@@ -1015,6 +1022,11 @@
                 <select class="rating-limit-select" ${user.deleted || user.role === 'admin' ? 'disabled' : ''} onchange="updateUserField('${user.id}', 'maxRating', this.value)">
                   ${ratingLimitOptions(user.role === 'admin' ? 'unrestricted' : user.maxRating)}
                 </select>
+              </td>
+              <td data-label="Stremio Search">
+                <label class="inline-check ${stremioSearchGlobalEnabled ? '' : 'disabled'}">
+                  <input type="checkbox" aria-label="Stremio Search" ${user.searchEnabled ? 'checked' : ''} ${user.deleted || !stremioSearchGlobalEnabled ? 'disabled' : ''} onchange="updateUserField('${user.id}', 'searchEnabled', this.checked)">
+                </label>
               </td>
               <td data-label="Password">
                 <div class="user-actions">
@@ -1049,6 +1061,7 @@
       maxRating: document.getElementById('modalRole').value === 'admin'
         ? 'unrestricted'
         : document.getElementById('modalMaxRating').value,
+      searchEnabled: defaultSearchEnabledForRole(document.getElementById('modalRole').value),
       pendingPassword: password,
       isNew: true,
       deleted: false,
@@ -1072,6 +1085,7 @@
     user.role = value
     if (value === 'admin') user.maxRating = 'unrestricted'
     if (value === 'kids' && (!user.maxRating || user.maxRating === 'unrestricted')) user.maxRating = defaultRatingLimitForRole(value)
+    user.searchEnabled = defaultSearchEnabledForRole(value)
     renderUsers()
     _markDirty()
   }
@@ -1404,6 +1418,7 @@
             password: user.pendingPassword,
             role: user.role,
             maxRating: user.role === 'admin' ? 'unrestricted' : user.maxRating || 'unrestricted',
+            searchEnabled: user.searchEnabled === true,
           }
         : {
             id: user.id,
@@ -1411,6 +1426,7 @@
             ...(user.pendingPassword ? { password: user.pendingPassword } : {}),
             role: user.role,
             maxRating: user.role === 'admin' ? 'unrestricted' : user.maxRating || 'unrestricted',
+            searchEnabled: user.searchEnabled === true,
           }
 
       const userRes = await fetch('/ui/users-data', {

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -2100,6 +2100,31 @@ label {
   text-overflow: ellipsis;
 }
 
+.user-table .role-select {
+  width: 5rem;
+  min-width: 5rem;
+}
+
+.user-table .inline-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  color: var(--text);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.user-table .inline-check input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+}
+
+.user-table .inline-check.disabled {
+  opacity: .45;
+  cursor: not-allowed;
+}
+
 .username-cell {
   font-size: 14px;
 }
@@ -2545,13 +2570,16 @@ body.dashboard-page {
 
   .settings-page .user-table tbody tr {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(104px, .45fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     grid-template-areas:
-      "identity role"
+      "identity identity"
+      "role role"
       "limit limit"
+      "search search"
       "password action";
-    gap: 10px;
-    padding: 12px;
+    gap: 14px 10px;
+    align-items: start;
+    padding: 14px;
     border-bottom: 1px solid var(--border);
   }
 
@@ -2570,10 +2598,23 @@ body.dashboard-page {
   .settings-page .user-table tbody td:nth-child(1) { grid-area: identity; }
   .settings-page .user-table tbody td:nth-child(2) { grid-area: role; }
   .settings-page .user-table tbody td:nth-child(3) { grid-area: limit; }
-  .settings-page .user-table tbody td:nth-child(4) { grid-area: password; }
-  .settings-page .user-table tbody td:nth-child(5) { grid-area: action; }
+  .settings-page .user-table tbody td:nth-child(4) { grid-area: search; }
+  .settings-page .user-table tbody td:nth-child(5) { grid-area: password; }
+  .settings-page .user-table tbody td:nth-child(6) { grid-area: action; }
 
   .settings-page .user-table tbody td::before {
+    content: attr(data-label) ":";
+    display: block;
+    margin-bottom: 6px;
+    color: var(--muted-strong);
+    font-size: 11px;
+    font-weight: 750;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .settings-page .user-table tbody td:nth-child(5)::before,
+  .settings-page .user-table tbody td:nth-child(6)::before {
     display: none;
   }
 
@@ -2585,9 +2626,24 @@ body.dashboard-page {
     width: 100%;
   }
 
+  .settings-page .user-table .role-select {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .settings-page .user-table .inline-check {
+    min-height: 38px;
+    margin-bottom: 0;
+  }
+
   .settings-page .user-actions {
     align-items: stretch;
     gap: 6px;
+    margin-left: 0;
+  }
+
+  .settings-page .user-table tbody td:nth-child(5) .user-actions {
+    flex-direction: column;
   }
 
   .settings-page .user-actions .btn {
@@ -2596,6 +2652,7 @@ body.dashboard-page {
   }
 
   .settings-page .password-state {
+    display: block;
     white-space: normal;
   }
 
@@ -2891,13 +2948,16 @@ body.dashboard-page {
 
   .user-table tbody tr {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(104px, .45fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     grid-template-areas:
-      "identity role"
+      "identity identity"
+      "role role"
       "limit limit"
+      "search search"
       "password action";
-    gap: 10px;
-    padding: 12px;
+    gap: 14px 10px;
+    align-items: start;
+    padding: 14px;
     border-bottom: 1px solid var(--border);
   }
 
@@ -2916,10 +2976,23 @@ body.dashboard-page {
   .user-table tbody td:nth-child(1) { grid-area: identity; }
   .user-table tbody td:nth-child(2) { grid-area: role; }
   .user-table tbody td:nth-child(3) { grid-area: limit; }
-  .user-table tbody td:nth-child(4) { grid-area: password; }
-  .user-table tbody td:nth-child(5) { grid-area: action; }
+  .user-table tbody td:nth-child(4) { grid-area: search; }
+  .user-table tbody td:nth-child(5) { grid-area: password; }
+  .user-table tbody td:nth-child(6) { grid-area: action; }
 
   .user-table tbody td::before {
+    content: attr(data-label) ":";
+    display: block;
+    margin-bottom: 6px;
+    color: var(--muted-strong);
+    font-size: 11px;
+    font-weight: 750;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .user-table tbody td:nth-child(5)::before,
+  .user-table tbody td:nth-child(6)::before {
     display: none;
   }
 
@@ -2931,9 +3004,24 @@ body.dashboard-page {
     width: 100%;
   }
 
+  .user-table .role-select {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .user-table .inline-check {
+    min-height: 38px;
+    margin-bottom: 0;
+  }
+
   .user-actions {
     align-items: stretch;
     gap: 6px;
+    margin-left: 0;
+  }
+
+  .user-table tbody td:nth-child(5) .user-actions {
+    flex-direction: column;
   }
 
   .user-actions .btn {
@@ -2942,6 +3030,7 @@ body.dashboard-page {
   }
 
   .password-state {
+    display: block;
     white-space: normal;
   }
 


### PR DESCRIPTION
## Summary

This PR adds a Jellyfin-compatible `/search` mount for Infuse users who need a separate search-only server connection while keeping their normal Fetcherr connection in Library Mode.

- Adds `/search` as a separate Jellyfin server identity (`Fetcherr Search`) with no library folders or library browse items.
- Keeps search result details, media source selection, and playback paths available through the search-only mount.
- Adds a per-user Stremio Search setting layered on top of the global Stremio search setting.
- Preserves local Fetcherr library search even when external Stremio search is disabled.
- Returns a visible `Fetcherr Search Disabled` media-shaped result when external search is disabled and no local library result exists, so clients like Infuse do not silently show zero results.
- Updates Settings user controls and mobile layout for the new per-user toggle.
- Documents the Infuse Library Mode plus `/search` workflow and removes the unsupported InfuseSync plugin instruction.

## Version

Proposed release version: `1.7.2`.

`package.json` and `package-lock.json` are updated from `1.7.1` to `1.7.2`.

## Upstream/Fork Comparison

This PR branch is intentionally clean: it is a single squashed commit based on current `upstream/main` (`d5aa133`). The fork's `origin/main` was 14 commits ahead of upstream, so this branch was created from upstream and the resulting feature tree was applied as one PR commit.

The resulting tree matches the current fork `origin/main` feature state.

## Validation

- `npm run build`
- `git diff --check`
- Local Docker smoke checks against `/search` for enabled and disabled Stremio Search users
- Mock Jellyfin client verified search/details/media source flow for enabled search
