### PR TITLE
Improve media source selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For shows, Fetcherr hydrates search results into seasons and aired episodes so c
 
 Fetcherr can optionally expose multiple cached stream candidates as Jellyfin media sources. Infuse presents these as selectable versions before playback (long press on play button), which is useful when a provider returns multiple quality, codec, or source options for the same movie or episode.
 
-Enable **Media source selection** in Settings to offer source choices. By default Fetcherr keeps automatic playback behavior and selects a stream itself. The Settings UI also lets you choose whether to offer 5 or 10 sources.
+Enable **Media source selection** in Settings to offer source choices. By default Fetcherr keeps automatic playback behavior and selects a stream itself. The Settings UI also lets you choose whether to offer 5, 10, or 20 sources.
 
 ## Connecting Infuse
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,14 +99,16 @@ export function parseStremioSearchSource(value: string | undefined): StremioSear
   if (value === 'addon' || value === 'trakt') return value
   return 'cinemeta'
 }
-export type MediaSourceLimit = 5 | 10
+export type MediaSourceLimit = 5 | 10 | 20
 
 export function parseStreamRankingMode(value: string | undefined): StreamRankingMode {
   return value === 'provider' ? 'provider' : 'fetcherr'
 }
 
 export function parseMediaSourceLimit(value: string | undefined): MediaSourceLimit {
-  return value === '5' ? 5 : 10
+  if (value === '5') return 5
+  if (value === '20') return 20
+  return 10
 }
 
 export type ShowAddDefaultMode = 'all' | 'latest'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1308,104 +1308,6 @@ function normalizedCodecLabel(text: string): string | undefined {
   return undefined
 }
 
-type StreamResolutionBucket = '2160p' | '1080p' | '720p' | '480p' | 'unknown'
-type StreamCodecBucket = 'h265' | 'h264' | 'av1' | 'other'
-type StreamVarietyKey = `${StreamResolutionBucket}:${StreamCodecBucket}`
-
-const STREAM_VARIETY_KEY_PRIORITY: StreamVarietyKey[] = [
-  '2160p:h265',
-  '2160p:h264',
-  '1080p:h265',
-  '1080p:h264',
-  '2160p:av1',
-  '1080p:av1',
-  '2160p:other',
-  '1080p:other',
-  '720p:h265',
-  '720p:h264',
-  '720p:av1',
-  '720p:other',
-  '480p:h265',
-  '480p:h264',
-  '480p:av1',
-  '480p:other',
-  'unknown:h265',
-  'unknown:h264',
-  'unknown:av1',
-  'unknown:other',
-]
-
-function streamResolutionBucket(stream: Stream): StreamResolutionBucket {
-  const text = streamMetadataText(stream)
-  if (/\b(2160p|4k|uhd)\b/i.test(text)) return '2160p'
-  if (/\b1080p\b/i.test(text)) return '1080p'
-  if (/\b720p\b/i.test(text)) return '720p'
-  if (/\b480p\b/i.test(text)) return '480p'
-  return 'unknown'
-}
-
-function streamCodecBucket(stream: Stream): StreamCodecBucket {
-  const text = streamMetadataText(stream)
-  if (/\bhevc\b|h\.?265\b|x265\b/i.test(text)) return 'h265'
-  if (/\bh\.?264\b|x264\b|avc\b/i.test(text)) return 'h264'
-  if (/\bav1\b/i.test(text)) return 'av1'
-  return 'other'
-}
-
-function streamVarietyKey(stream: Stream): StreamVarietyKey {
-  return `${streamResolutionBucket(stream)}:${streamCodecBucket(stream)}`
-}
-
-function selectPlaybackMediaSourceStreams(streams: Stream[], limit: number): Stream[] {
-  if (limit <= 0) return []
-  if (streams.length <= limit) return streams
-
-  const buckets = new Map<StreamVarietyKey, Stream[]>()
-  const firstSeenKeys: StreamVarietyKey[] = []
-  for (const stream of streams) {
-    const key = streamVarietyKey(stream)
-    const bucket = buckets.get(key)
-    if (bucket) {
-      bucket.push(stream)
-    } else {
-      buckets.set(key, [stream])
-      firstSeenKeys.push(key)
-    }
-  }
-
-  const priorityKeys = [
-    ...STREAM_VARIETY_KEY_PRIORITY.filter(key => buckets.has(key)),
-    ...firstSeenKeys.filter(key => !STREAM_VARIETY_KEY_PRIORITY.includes(key)),
-  ]
-  const selected: Stream[] = []
-  const selectedStreams = new Set<Stream>()
-
-  while (selected.length < limit) {
-    let addedInRound = false
-    for (const key of priorityKeys) {
-      const bucket = buckets.get(key)
-      const stream = bucket?.shift()
-      if (!stream || selectedStreams.has(stream)) continue
-      selected.push(stream)
-      selectedStreams.add(stream)
-      addedInRound = true
-      if (selected.length >= limit) break
-    }
-    if (!addedInRound) break
-  }
-
-  if (selected.length < limit) {
-    for (const stream of streams) {
-      if (selectedStreams.has(stream)) continue
-      selected.push(stream)
-      selectedStreams.add(stream)
-      if (selected.length >= limit) break
-    }
-  }
-
-  return selected
-}
-
 function streamBitrateSortValue(stream: Stream, runtimeTicks: number): number {
   return streamBitrate(streamSizeBytes(stream), runtimeTicks) ?? 0
 }
@@ -1586,7 +1488,7 @@ async function buildPlaybackMediaSources(input: {
   try {
     const { streams, label, fileHint } = await playbackStreamsForPath(input.playPath, input.playbackClient, false)
     const qualityRanked = streams.filter(stream => (stream.url || extractHashFromStream(stream)) && streamEligibleForMediaSourceSelection(stream))
-    const usable = selectPlaybackMediaSourceStreams(qualityRanked, config.mediaSourceLimit)
+    const usable = qualityRanked.slice(0, config.mediaSourceLimit)
 
     if (!usable.length) return [fallbackSource]
 

--- a/src/sootio.ts
+++ b/src/sootio.ts
@@ -387,13 +387,13 @@ function sourceScore(s: Stream): number {
   return 2
 }
 
-// Codec quality score — higher is better. Playback compatibility is handled
-// later by resolving and probing the selected candidate before returning it.
+// Prefer broadly supported HEVC and H.264 playback over AV1. AV1 remains
+// preferable to unknown codecs, but is not consistently supported by clients.
 function codecScore(s: Stream): number {
   const text = streamText(s)
-  if (/\bav1\b/.test(text))                      return 4
-  if (/\bhevc\b|h\.?265\b|x265\b/.test(text))   return 3
-  if (/\bh\.?264\b|x264\b|avc\b/.test(text))    return 2
+  if (/\bhevc\b|h\.?265\b|x265\b/.test(text))   return 4
+  if (/\bh\.?264\b|x264\b|avc\b/.test(text))    return 3
+  if (/\bav1\b/.test(text))                      return 2
   if (/\bxvid\b|\bdivx\b/.test(text))            return 0
   return 1
 }

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -115,6 +115,7 @@
     <div class="field" id="mediaSourceLimitField" hidden>
       <label for="mediaSourceLimit">Sources Offered</label>
       <select id="mediaSourceLimit">
+        <option value="20">20 sources</option>
         <option value="10">10 sources</option>
         <option value="5">5 sources</option>
       </select>
@@ -902,7 +903,7 @@
     document.getElementById('stremioSearchEnabled').checked = d.stremioSearchEnabled === true
     document.getElementById('stremioSearchSource').value = d.stremioSearchSource || 'cinemeta'
     syncStremioSearchSourceVisibility()
-    document.getElementById('mediaSourceLimit').value = String(d.mediaSourceLimit === 5 ? 5 : 10)
+    document.getElementById('mediaSourceLimit').value = String([5, 10, 20].includes(d.mediaSourceLimit) ? d.mediaSourceLimit : 10)
     syncMediaSourceLimitVisibility()
     setSecretPlaceholder('rdApiKey', hasStoredRdApiKey, 'Enter your Real-Debrid API key')
     setSecretPlaceholder('torBoxApiKey', hasStoredTorBoxApiKey, 'Enter your TorBox API key')


### PR DESCRIPTION
## Summary

- preserve stream ranking when exposing selectable media versions
- prefer broadly supported codecs over AV1 when otherwise comparable
- increase the configurable media source limit to 20

## Impact

Clients receive media source options in the intended ranking order, with more compatible codecs preferred and additional selectable sources available when configured.

## Validation

- `npm run build`
- `docker build -t fetcherr:test .`
- `git diff --check upstream/main...HEAD`
