### PR TITLE
Improve list presentation settings and menu controls

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,16 +25,62 @@ export function parseTraktLists(value: string): string[] {
 }
 
 export type TraktListMode = 'library' | 'folder' | 'collection' | 'browse_only'
+export type ListPresentationMode = TraktListMode
 
-export function parseTraktListModes(value: string): Record<string, TraktListMode> {
+export interface ListPresentation {
+  includeInLibrary: boolean
+  showAsFolder: boolean
+  showAsCollection: boolean
+}
+
+export const DEFAULT_LIST_PRESENTATION: ListPresentation = {
+  includeInLibrary: true,
+  showAsFolder: false,
+  showAsCollection: false,
+}
+
+const LIST_PRESENTATION_MODES = new Set<string>(['library', 'folder', 'collection', 'browse_only'])
+
+export function presentationFromLegacyMode(mode: unknown): ListPresentation | null {
+  if (mode === 'library') return { includeInLibrary: true, showAsFolder: false, showAsCollection: false }
+  if (mode === 'folder') return { includeInLibrary: true, showAsFolder: true, showAsCollection: false }
+  if (mode === 'browse_only') return { includeInLibrary: false, showAsFolder: true, showAsCollection: false }
+  if (mode === 'collection') return { includeInLibrary: true, showAsFolder: false, showAsCollection: true }
+  return null
+}
+
+export function normalizeListPresentation(value: unknown, fallback: ListPresentation = DEFAULT_LIST_PRESENTATION): ListPresentation {
+  const legacy = presentationFromLegacyMode(value)
+  if (legacy) return legacy
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>
+    const nestedLegacy = presentationFromLegacyMode(record.mode)
+    const base = nestedLegacy ?? fallback
+    return {
+      includeInLibrary: typeof record.includeInLibrary === 'boolean' ? record.includeInLibrary : base.includeInLibrary,
+      showAsFolder: typeof record.showAsFolder === 'boolean' ? record.showAsFolder : base.showAsFolder,
+      showAsCollection: typeof record.showAsCollection === 'boolean' ? record.showAsCollection : base.showAsCollection,
+    }
+  }
+  return { ...fallback }
+}
+
+export function isListPresentationEnabled(presentation: ListPresentation): boolean {
+  return presentation.includeInLibrary || presentation.showAsFolder || presentation.showAsCollection
+}
+
+export function parseTraktListModes(value: string): Record<string, ListPresentation> {
   if (!value.trim()) return {}
   try {
     const parsed = JSON.parse(value)
     if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      const MODES = new Set(['library', 'folder', 'collection', 'browse_only'])
-      const result: Record<string, TraktListMode> = {}
+      const result: Record<string, ListPresentation> = {}
       for (const [k, v] of Object.entries(parsed)) {
-        if (typeof v === 'string' && MODES.has(v)) result[k] = v as TraktListMode
+        if (typeof v === 'string' && LIST_PRESENTATION_MODES.has(v)) {
+          result[k] = normalizeListPresentation(v)
+        } else if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
+          result[k] = normalizeListPresentation(v)
+        }
       }
       return result
     }
@@ -48,9 +94,21 @@ export interface MdblistListEntry {
   url: string
   name?: string
   mode?: MdblistListMode
+  includeInLibrary?: boolean
+  showAsFolder?: boolean
+  showAsCollection?: boolean
+  maxItems?: number
 }
 
 const MDBLIST_MODES = new Set<string>(['library', 'folder', 'collection', 'browse_only'])
+
+function mdblistEntryPresentation(entry: Record<string, unknown>): ListPresentation | null {
+  const hasFlags = typeof entry.includeInLibrary === 'boolean'
+    || typeof entry.showAsFolder === 'boolean'
+    || typeof entry.showAsCollection === 'boolean'
+  if (hasFlags) return normalizeListPresentation(entry)
+  return presentationFromLegacyMode(entry.mode)
+}
 
 export function parseMdblistLists(value: string): MdblistListEntry[] {
   if (!value.trim()) return []
@@ -61,11 +119,16 @@ export function parseMdblistLists(value: string): MdblistListEntry[] {
       if (Array.isArray(parsed)) {
         return (parsed as unknown[])
           .filter((e): e is Record<string, unknown> => typeof e === 'object' && e !== null && typeof (e as Record<string, unknown>).url === 'string')
-          .map(e => ({
-            url: String(e.url).trim(),
-            ...(e.name && String(e.name).trim() ? { name: String(e.name).trim() } : {}),
-            ...(typeof e.mode === 'string' && MDBLIST_MODES.has(e.mode) ? { mode: e.mode as MdblistListMode } : {}),
-          }))
+          .map(e => {
+            const presentation = mdblistEntryPresentation(e)
+            return {
+              url: String(e.url).trim(),
+              ...(e.name && String(e.name).trim() ? { name: String(e.name).trim() } : {}),
+              ...(typeof e.mode === 'string' && MDBLIST_MODES.has(e.mode) && !presentation ? { mode: e.mode as MdblistListMode } : {}),
+              ...(presentation ? presentation : {}),
+              ...(Number.isFinite(Number(e.maxItems)) && Number(e.maxItems) > 0 ? { maxItems: Math.trunc(Number(e.maxItems)) } : {}),
+            }
+          })
           .filter(e => e.url)
       }
     } catch { /* fall through to legacy */ }

--- a/src/db.ts
+++ b/src/db.ts
@@ -319,6 +319,7 @@ CREATE TABLE IF NOT EXISTS source_items (
   source_key TEXT    NOT NULL,
   media_type TEXT    NOT NULL CHECK (media_type IN ('movie', 'show')),
   tmdb_id    INTEGER NOT NULL,
+  source_position INTEGER NOT NULL DEFAULT 0,
   synced_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
   PRIMARY KEY (source_key, media_type, tmdb_id)
 );
@@ -485,6 +486,7 @@ export function getDb(): Database.Database {
     try { _db.exec(`ALTER TABLE user_item_data ADD COLUMN trakt_last_watched_at TEXT NOT NULL DEFAULT ''`) } catch { /* already exists */ }
     try { _db.exec(`ALTER TABLE music_meta_tracks ADD COLUMN youtube_id TEXT NOT NULL DEFAULT ''`) } catch { /* already exists */ }
     try { _db.exec(`ALTER TABLE music_meta_tracks ADD COLUMN youtube_resolved_at TEXT NOT NULL DEFAULT ''`) } catch { /* already exists */ }
+    try { _db.exec(`ALTER TABLE source_items ADD COLUMN source_position INTEGER NOT NULL DEFAULT 0`) } catch { /* already exists */ }
     try { _db.exec(`CREATE TABLE IF NOT EXISTS torbox_cleanup_jobs (
       download_url TEXT PRIMARY KEY,
       torrent_id   INTEGER NOT NULL,
@@ -1994,14 +1996,14 @@ export function listSourceKeys(prefix?: string): string[] {
   return (rows as { source_key: string }[]).map(r => r.source_key)
 }
 
-export function listSourceItems(sourceKey: string): Array<{ mediaType: MediaType; tmdbId: number }> {
+export function listSourceItems(sourceKey: string): Array<{ mediaType: MediaType; tmdbId: number; sourcePosition: number; syncedAt: string }> {
   const rows = getDb().prepare(`
-    SELECT media_type, tmdb_id
+    SELECT media_type, tmdb_id, source_position, synced_at
     FROM source_items
     WHERE source_key = ?
-    ORDER BY media_type ASC, tmdb_id ASC
-  `).all(sourceKey) as Array<{ media_type: MediaType; tmdb_id: number }>
-  return rows.map(row => ({ mediaType: row.media_type, tmdbId: row.tmdb_id }))
+    ORDER BY source_position ASC, media_type ASC, tmdb_id ASC
+  `).all(sourceKey) as Array<{ media_type: MediaType; tmdb_id: number; source_position: number; synced_at: string }>
+  return rows.map(row => ({ mediaType: row.media_type, tmdbId: row.tmdb_id, sourcePosition: row.source_position, syncedAt: row.synced_at }))
 }
 
 export function listSourceKeysForItem(mediaType: MediaType, tmdbId: number): string[] {
@@ -2079,8 +2081,22 @@ export function replaceSourceItems(
   mediaType: MediaType,
   tmdbIds: number[],
 ): number[] {
+  return replaceSourceItemsWithPositions(sourceKey, mediaType, tmdbIds.map((tmdbId, idx) => ({ tmdbId, sourcePosition: idx + 1 })))
+}
+
+export function replaceSourceItemsWithPositions(
+  sourceKey: string,
+  mediaType: MediaType,
+  items: Array<{ tmdbId: number; sourcePosition?: number }>,
+): number[] {
   const db = getDb()
-  const ids = uniqTmdbIds(tmdbIds)
+  const byId = new Map<number, number>()
+  for (const item of items) {
+    if (!Number.isFinite(item.tmdbId) || item.tmdbId <= 0 || byId.has(item.tmdbId)) continue
+    const sourcePosition = Number.isFinite(item.sourcePosition) && (item.sourcePosition ?? 0) > 0 ? Math.trunc(item.sourcePosition ?? 0) : byId.size + 1
+    byId.set(item.tmdbId, sourcePosition)
+  }
+  const ids = [...byId.keys()]
   const current = (db.prepare(
     `SELECT tmdb_id FROM source_items WHERE source_key = ? AND media_type = ?`
   ).all(sourceKey, mediaType) as { tmdb_id: number }[]).map(r => r.tmdb_id)
@@ -2089,14 +2105,15 @@ export function replaceSourceItems(
   const removed = current.filter(id => !nextSet.has(id))
 
   const insertStmt = db.prepare(`
-    INSERT INTO source_items (source_key, media_type, tmdb_id, synced_at)
-    VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    INSERT INTO source_items (source_key, media_type, tmdb_id, source_position, synced_at)
+    VALUES (?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ','now'))
     ON CONFLICT(source_key, media_type, tmdb_id) DO UPDATE SET
+      source_position = excluded.source_position,
       synced_at = excluded.synced_at
   `)
 
   db.transaction(() => {
-    for (const id of ids) insertStmt.run(sourceKey, mediaType, id)
+    for (const id of ids) insertStmt.run(sourceKey, mediaType, id, byId.get(id) ?? 0)
 
     if (!ids.length) {
       db.prepare(`DELETE FROM source_items WHERE source_key = ? AND media_type = ?`).run(sourceKey, mediaType)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Fastify from 'fastify'
 import { parseTorrentTitle, type ParsedResult as ParsedTorrentTitleResult } from '@viren070/parse-torrent-title'
 import { randomBytes } from 'node:crypto'
-import { collectStreamProviderUrls, config, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseFoldersSetting, parseEnglishStreamMode, parseMdblistLists, parseMediaSourceLimit, parseMovieReleaseMode, parseMusicAddonUrls, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists, parseTraktListModes, parseStremioSearchSource } from './config.js'
+import { collectStreamProviderUrls, config, isListPresentationEnabled, normalizeListPresentation, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseFoldersSetting, parseEnglishStreamMode, parseMdblistLists, parseMediaSourceLimit, parseMovieReleaseMode, parseMusicAddonUrls, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseTraktLists, parseTraktListModes, parseStremioSearchSource } from './config.js'
 import { getDb, getAllSettings } from './db.js'
 import { jellyfinRoutes, resolveJellyfinUser } from './jellyfin/index.js'
 import { uiRoutes } from './ui/routes.js'
@@ -1879,6 +1879,7 @@ async function runSyncInternal() {
   }
 
   for (const slug of config.traktLists) {
+    if (!isListPresentationEnabled(normalizeListPresentation(config.traktListModes[slug]))) continue
     await syncTraktList(slug).catch(err => app.log.error(`List sync "${slug}" failed: ${err}`))
   }
   if (config.traktWatchHistory) {
@@ -1893,6 +1894,7 @@ async function runSyncInternal() {
   }
 
   for (const entry of config.mdblistLists) {
+    if (!isListPresentationEnabled(normalizeListPresentation(entry))) continue
     await syncMdblistList(entry.url).catch(err => app.log.error(`MDBList sync "${entry.url}" failed: ${err}`))
   }
   const staleMdblistCleanup = cleanupRemovedMdblistListSources(config.mdblistLists.map(e => e.url))

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyReply } from 'fastify'
 import { createHash, randomBytes } from 'node:crypto'
 import { lookup } from 'node:dns/promises'
 import { isIP } from 'node:net'
-import { config, type ListFoldersSetting } from '../config.js'
+import { config, normalizeListPresentation, type ListFoldersSetting, type ListPresentation, type MdblistListEntry } from '../config.js'
 import {
   listMovies, countMovies, getMovieByTmdbId,
   listUsers, getUserData, saveProgress, markPlayed, markUnplayed, listResumeItemIds, countResumeItems, getAllPlayedItemIds,
@@ -51,30 +51,30 @@ const FOLDER_ID = MOVIES_FOLDER_ID
 
 const API_LIBRARY_FILTER = { availableOnly: true as const }
 
-function traktListMode(slug: string): string {
-  return config.traktListModes[slug] ?? 'library'
+function traktListPresentation(slug: string): ListPresentation {
+  const configured = config.traktListModes[slug]
+  if (configured) return normalizeListPresentation(configured)
+  return {
+    includeInLibrary: true,
+    showAsFolder: isTraktListFolder(config.traktFolders, slug),
+    showAsCollection: config.traktCollections,
+  }
 }
 
 function isTraktEntryVisible(slug: string): boolean {
-  const mode = traktListMode(slug)
-  if (mode === 'folder' || mode === 'browse_only') return true
-  if (mode === 'collection' || mode === 'library') return false
-  return isTraktListFolder(config.traktFolders, slug)
+  return traktListPresentation(slug).showAsFolder
 }
 
 function isTraktEntryCollection(slug: string): boolean {
-  const m = config.traktListModes[slug]
-  if (m === 'collection') return true
-  if (m != null && m !== 'library') return false
-  return config.traktCollections
+  return traktListPresentation(slug).showAsCollection
 }
 
 function apiLibraryFilter(): { availableOnly: true; excludeSourceKeys?: string[] } {
   const mdblistKeys = config.mdblistLists
-    .filter(e => e.mode === 'browse_only')
+    .filter(e => !mdblistListPresentation(e).includeInLibrary)
     .map(e => mdblistFolderSourceKey(e.url))
   const traktKeys = config.traktLists
-    .filter(slug => config.traktListModes[slug] === 'browse_only')
+    .filter(slug => !traktListPresentation(slug).includeInLibrary)
     .map(slug => `trakt:list:${slug}`)
   const keys = [...mdblistKeys, ...traktKeys]
   return keys.length ? { availableOnly: true, excludeSourceKeys: keys } : API_LIBRARY_FILTER
@@ -171,9 +171,23 @@ function normalizePlaybackItemId(itemId: string): string {
   return itemId
 }
 
-function traktCollectionSlugToId(slug: string): string {
-  const digest = createHash('md5').update(`trakt:list:${slug}`).digest('hex').slice(0, 12)
+function traktListId(slug: string, kind: 'folder' | 'collection'): string {
+  const digest = createHash('md5').update(`trakt:list:${kind}:${slug}`).digest('hex').slice(0, 12)
   return `00000000-0000-4000-8006-${digest}`
+}
+
+function traktFolderSlugToId(slug: string): string {
+  return traktListId(slug, 'folder')
+}
+
+function traktCollectionSlugToId(slug: string): string {
+  return traktListId(slug, 'collection')
+}
+
+function idToTraktFolderSlug(id: string): string | null {
+  const m = id.match(/^00000000-0000-4000-8006-([0-9a-f]{12})$/i)
+  if (!m) return null
+  return config.traktLists.find(slug => traktFolderSlugToId(slug) === id) ?? null
 }
 
 function idToTraktCollectionSlug(id: string): string | null {
@@ -667,10 +681,18 @@ function isMdblistListFolder(setting: ListFoldersSetting, url: string): boolean 
   return setting.some(s => path === s || path.endsWith(`/${s}`))
 }
 
-function isMdblistEntryVisible(entry: { url: string; mode?: string }): boolean {
-  if (entry.mode === 'folder' || entry.mode === 'browse_only') return true
-  if (entry.mode === 'library' || entry.mode === 'collection') return false
-  return isMdblistListFolder(config.mdblistFolders, entry.url)
+function mdblistListPresentation(entry: MdblistListEntry): ListPresentation {
+  const hasPresentation = entry.includeInLibrary != null || entry.showAsFolder != null || entry.showAsCollection != null
+  if (hasPresentation || entry.mode) return normalizeListPresentation(entry)
+  return {
+    includeInLibrary: true,
+    showAsFolder: isMdblistListFolder(config.mdblistFolders, entry.url),
+    showAsCollection: false,
+  }
+}
+
+function isMdblistEntryVisible(entry: MdblistListEntry): boolean {
+  return mdblistListPresentation(entry).showAsFolder
 }
 
 function mdblistFolderUrlForId(id: string | null | undefined): string | null {
@@ -679,18 +701,26 @@ function mdblistFolderUrlForId(id: string | null | undefined): string | null {
   if (!url) return null
   const entry = config.mdblistLists.find(e => e.url === url)
   if (!entry) return null
-  if (entry.mode === 'folder' || entry.mode === 'browse_only' || entry.mode === 'collection') return url
-  return isMdblistListFolder(config.mdblistFolders, url) ? url : null
+  return mdblistListPresentation(entry).showAsFolder ? url : null
+}
+
+function mdblistCollectionUrlForId(id: string | null | undefined): string | null {
+  if (!id) return null
+  const url = idToMdblistCollectionListUrl(id)
+  if (!url) return null
+  const entry = config.mdblistLists.find(e => e.url === url)
+  if (!entry) return null
+  return mdblistListPresentation(entry).showAsCollection ? url : null
 }
 
 function hasAnyCollections(): boolean {
   return config.traktLists.some(slug => isTraktEntryCollection(slug))
-    || config.mdblistLists.some(e => e.mode === 'collection')
+    || config.mdblistLists.some(e => mdblistListPresentation(e).showAsCollection)
 }
 
-function buildMdblistCollectionItem(entry: { url: string; name?: string; mode?: string }, count: number) {
+function buildMdblistCollectionItem(entry: MdblistListEntry, count: number) {
   const path = mdblistListPathFromUrl(entry.url)
-  const id = mdblistFolderIdFromPath(path)
+  const id = mdblistCollectionIdFromPath(path)
   const name = nameForMdblistUrl(entry.url)
   return {
     Id: id, ServerId: SERVER_GUID, Name: name, SortName: name.toLowerCase(),
@@ -704,24 +734,35 @@ function buildMdblistCollectionItem(entry: { url: string; name?: string; mode?: 
 
 function mdblistCollectionItems(user: AppUser) {
   return config.mdblistLists
-    .filter(e => e.mode === 'collection')
+    .filter(e => mdblistListPresentation(e).showAsCollection)
     .map(e => buildMdblistCollectionItem(e, mdblistFolderMembers(user, e.url).length))
 }
 
-type CollectionMember = { mediaType: 'movie' | 'show'; tmdbId: number }
+type CollectionMember = { mediaType: 'movie' | 'show'; tmdbId: number; sourcePosition?: number; syncedAt?: string }
 type TraktCollectionItem = ReturnType<typeof buildTraktCollectionItem>
 type TraktCollectionSummary = { slug: string; members: CollectionMember[]; item: TraktCollectionItem }
 
 // ── MDBList folder helpers ─────────────────────────────────────────────────────
 
 function mdblistFolderIdFromPath(path: string): string {
-  const digest = createHash('md5').update(`mdblist:list:${path}`).digest('hex').slice(0, 12)
+  const digest = createHash('md5').update(`mdblist:list:folder:${path}`).digest('hex').slice(0, 12)
+  return `00000000-0000-4000-8009-${digest}`
+}
+
+function mdblistCollectionIdFromPath(path: string): string {
+  const digest = createHash('md5').update(`mdblist:list:collection:${path}`).digest('hex').slice(0, 12)
   return `00000000-0000-4000-8009-${digest}`
 }
 
 function idToMdblistListUrl(id: string): string | null {
   if (!id.match(/^00000000-0000-4000-8009-[0-9a-f]{12}$/i)) return null
   const entry = config.mdblistLists.find(e => mdblistFolderIdFromPath(mdblistListPathFromUrl(e.url)) === id)
+  return entry?.url ?? null
+}
+
+function idToMdblistCollectionListUrl(id: string): string | null {
+  if (!id.match(/^00000000-0000-4000-8009-[0-9a-f]{12}$/i)) return null
+  const entry = config.mdblistLists.find(e => mdblistCollectionIdFromPath(mdblistListPathFromUrl(e.url)) === id)
   return entry?.url ?? null
 }
 
@@ -740,6 +781,13 @@ function mdblistFolderSourceKey(listUrl: string): string {
   return `mdblist:list:${mdblistListPathFromUrl(listUrl)}`
 }
 
+function dateCreatedForSourcePosition(syncedAt: string | undefined, sourcePosition: number | undefined): string | undefined {
+  if (!sourcePosition || sourcePosition <= 0) return syncedAt
+  const baseMs = Date.parse(syncedAt ?? '')
+  if (!Number.isFinite(baseMs)) return syncedAt
+  return new Date(baseMs - ((sourcePosition - 1) * 1000)).toISOString()
+}
+
 function mdblistFolderMembers(user: AppUser, listUrl: string): CollectionMember[] {
   return listSourceItems(mdblistFolderSourceKey(listUrl)).filter(item => {
     if (isLibraryItemHidden(item.mediaType, item.tmdbId)) return false
@@ -752,19 +800,49 @@ function mdblistFolderMembers(user: AppUser, listUrl: string): CollectionMember[
   })
 }
 
-async function mdblistFolderContents(listUrl: string, user: AppUser) {
+function sortMdblistFolderItems<T extends Record<string, unknown>>(items: T[], sortBy?: string, sortOrder?: string): T[] {
+  const normalizedSort = (sortBy ?? '').split(',')[0].trim().toLowerCase()
+  const normalizedOrder = (sortOrder ?? '').split(',')[0].trim().toLowerCase()
+  const direction = normalizedOrder === 'ascending' || normalizedOrder === 'asc' ? 1 : -1
+  const compareStrings = (a: unknown, b: unknown) => String(a ?? '').localeCompare(String(b ?? ''), undefined, { sensitivity: 'base' })
+  const compareNumbers = (a: unknown, b: unknown) => (Number(a ?? 0) || 0) - (Number(b ?? 0) || 0)
+
+  return [...items].sort((a, b) => {
+    if (['sortname', 'name'].includes(normalizedSort)) return compareStrings(a.SortName ?? a.Name, b.SortName ?? b.Name) * direction
+    if (['communityrating', 'rating', 'imdbrating'].includes(normalizedSort)) return compareNumbers(a.CommunityRating, b.CommunityRating) * direction
+    if (['officialrating', 'parentalrating'].includes(normalizedSort)) return compareStrings(a.OfficialRating, b.OfficialRating) * direction
+    if (['premieredate', 'releasedate', 'productionyear'].includes(normalizedSort)) return compareStrings(a.PremiereDate ?? a.ProductionYear, b.PremiereDate ?? b.ProductionYear) * direction
+    if (['datecreated', 'dateshowadded', 'dateadded', 'addeddate'].includes(normalizedSort)) return compareStrings(a.DateCreated, b.DateCreated) * direction
+    if (['runtime', 'runtimeticks'].includes(normalizedSort)) return compareNumbers(a.RunTimeTicks, b.RunTimeTicks) * direction
+    return compareNumbers(a.SourcePosition, b.SourcePosition) || compareStrings(a.SortName ?? a.Name, b.SortName ?? b.Name)
+  })
+}
+
+async function mdblistFolderContents(listUrl: string, user: AppUser, sortBy?: string, sortOrder?: string) {
   const members = mdblistFolderMembers(user, listUrl)
-  const items = []
+  const items: Array<Record<string, unknown>> = []
   for (const member of members) {
     if (member.mediaType === 'movie') {
       const movie = getMovieByTmdbId(member.tmdbId)
-      if (movie && canUserAccessMovie(user, movie)) items.push(movieToItem(movie, user.id))
+      if (movie && canUserAccessMovie(user, movie)) {
+        items.push({
+          ...movieToItem(movie, user.id),
+          DateCreated: dateCreatedForSourcePosition(member.syncedAt, member.sourcePosition),
+          SourcePosition: member.sourcePosition ?? 0,
+        })
+      }
       continue
     }
     const show = getShowByTmdbId(member.tmdbId) ?? await fetchShowByTmdbId(member.tmdbId)
-    if (show && canUserAccessShow(user, show)) items.push(showToSeriesItem(show, user.id))
+    if (show && canUserAccessShow(user, show)) {
+      items.push({
+        ...showToSeriesItem(show, user.id),
+        DateCreated: dateCreatedForSourcePosition(member.syncedAt, member.sourcePosition),
+        SourcePosition: member.sourcePosition ?? 0,
+      })
+    }
   }
-  return items.sort((a, b) => String(a.SortName ?? a.Name ?? '').localeCompare(String(b.SortName ?? b.Name ?? '')))
+  return sortMdblistFolderItems(items, sortBy, sortOrder)
 }
 
 function buildMdblistFolderItem(listUrl: string, count: number) {
@@ -823,7 +901,7 @@ function buildTraktCollectionItem(slug: string, members: CollectionMember[]) {
 }
 
 function buildTraktFolderItem(slug: string, count: number) {
-  const id = traktCollectionSlugToId(slug)
+  const id = traktFolderSlugToId(slug)
   const name = humanizeCollectionSlug(slug.split('/').pop() ?? slug)
   return {
     Id: id, ServerId: SERVER_GUID, Name: name, SortName: name.toLowerCase(),
@@ -892,7 +970,7 @@ function traktCollectionItemsForUser(user: AppUser): TraktCollectionItem[] {
 
 function traktCollectionsFolderToItem(user: AppUser) {
   const traktSummaries = traktCollectionSummariesForUser(user)
-  const mdblistCollEntries = config.mdblistLists.filter(e => e.mode === 'collection')
+  const mdblistCollEntries = config.mdblistLists.filter(e => mdblistListPresentation(e).showAsCollection)
   const traktItemCount = traktSummaries.reduce((sum, s) => sum + s.members.length, 0)
   const mdblistItemCount = mdblistCollEntries.reduce((sum, e) => sum + mdblistFolderMembers(user, e.url).length, 0)
   return {
@@ -995,7 +1073,7 @@ function bestRootFolderImage(
   }
   if (id === COLLECTIONS_FOLDER_ID && hasAnyCollections()) {
     const traktMembers = traktCollectionSummariesForUser(visibleUser).flatMap(s => s.members)
-    const mdblistMembers = config.mdblistLists.filter(e => e.mode === 'collection').flatMap(e => mdblistFolderMembers(visibleUser, e.url))
+    const mdblistMembers = config.mdblistLists.filter(e => mdblistListPresentation(e).showAsCollection).flatMap(e => mdblistFolderMembers(visibleUser, e.url))
     return bestCollectionArtwork([...traktMembers, ...mdblistMembers])
   }
   return null
@@ -2268,7 +2346,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       : []),
     ...config.traktLists.filter(slug => isTraktEntryVisible(slug)).map(slug => {
       const name = humanizeCollectionSlug(slug.split('/').pop() ?? slug)
-      return { Name: name, CollectionType: 'boxsets', ItemId: traktCollectionSlugToId(slug), Locations: [`/trakt/${slug}`] }
+      return { Name: name, CollectionType: 'boxsets', ItemId: traktFolderSlugToId(slug), Locations: [`/trakt/${slug}`] }
     }),
     ...config.mdblistLists.filter(entry => isMdblistEntryVisible(entry)).map(entry => {
       const p = mdblistListPathFromUrl(entry.url)
@@ -2283,7 +2361,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     { Name: 'Shows',  Id: SHOWS_FOLDER_ID,  Type: 'tvshows' },
     ...(hasAnyCollections() ? [{ Name: 'Collections', Id: COLLECTIONS_FOLDER_ID, Type: 'boxsets' }] : []),
     ...config.traktLists.filter(slug => isTraktEntryVisible(slug)).map(slug => ({
-      Name: humanizeCollectionSlug(slug.split('/').pop() ?? slug), Id: traktCollectionSlugToId(slug), Type: 'boxsets',
+      Name: humanizeCollectionSlug(slug.split('/').pop() ?? slug), Id: traktFolderSlugToId(slug), Type: 'boxsets',
     })),
     ...config.mdblistLists.filter(entry => isMdblistEntryVisible(entry)).map(entry => {
       const p = mdblistListPathFromUrl(entry.url)
@@ -2295,7 +2373,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     { Name: 'Shows',  Id: SHOWS_FOLDER_ID,  Type: 'tvshows' },
     ...(hasAnyCollections() ? [{ Name: 'Collections', Id: COLLECTIONS_FOLDER_ID, Type: 'boxsets' }] : []),
     ...config.traktLists.filter(slug => isTraktEntryVisible(slug)).map(slug => ({
-      Name: humanizeCollectionSlug(slug.split('/').pop() ?? slug), Id: traktCollectionSlugToId(slug), Type: 'boxsets',
+      Name: humanizeCollectionSlug(slug.split('/').pop() ?? slug), Id: traktFolderSlugToId(slug), Type: 'boxsets',
     })),
     ...config.mdblistLists.filter(entry => isMdblistEntryVisible(entry)).map(entry => {
       const p = mdblistListPathFromUrl(entry.url)
@@ -2493,12 +2571,22 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
 
     const mdblistUrl = mdblistFolderUrlForId(ParentId)
     if (mdblistUrl) {
-      const items = await mdblistFolderContents(mdblistUrl, user)
+      const items = await mdblistFolderContents(mdblistUrl, user, SortBy, SortOrder)
+      return { Items: pagedItems(items, offset, limit), TotalRecordCount: items.length, StartIndex: offset }
+    }
+    const mdblistCollectionUrl = mdblistCollectionUrlForId(ParentId)
+    if (mdblistCollectionUrl) {
+      const items = await mdblistFolderContents(mdblistCollectionUrl, user, SortBy, SortOrder)
       return { Items: pagedItems(items, offset, limit), TotalRecordCount: items.length, StartIndex: offset }
     }
 
+    const folderSlug = ParentId ? idToTraktFolderSlug(ParentId) : null
+    if (folderSlug && isTraktEntryVisible(folderSlug)) {
+      const items = await traktCollectionContents(folderSlug, user)
+      return { Items: pagedItems(items, offset, limit), TotalRecordCount: items.length, StartIndex: offset }
+    }
     const collectionSlug = ParentId ? idToTraktCollectionSlug(ParentId) : null
-    if (collectionSlug && (isTraktEntryVisible(collectionSlug) || isTraktEntryCollection(collectionSlug))) {
+    if (collectionSlug && isTraktEntryCollection(collectionSlug)) {
       const items = await traktCollectionContents(collectionSlug, user)
       return { Items: pagedItems(items, offset, limit), TotalRecordCount: items.length, StartIndex: offset }
     }
@@ -2843,20 +2931,23 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       return traktCollectionsFolderToItem(currentUser)
     }
 
-    const collectionSlug = idToTraktCollectionSlug(id)
-    if (collectionSlug && isTraktListFolder(config.traktFolders, collectionSlug)) {
-      return buildTraktFolderItem(collectionSlug, collectionMembersForUser(currentUser, collectionSlug).length)
+    const folderSlug = idToTraktFolderSlug(id)
+    if (folderSlug && isTraktEntryVisible(folderSlug)) {
+      return buildTraktFolderItem(folderSlug, collectionMembersForUser(currentUser, folderSlug).length)
     }
+    const collectionSlug = idToTraktCollectionSlug(id)
     if (collectionSlug && isTraktEntryCollection(collectionSlug)) {
       return traktCollectionToItem(collectionSlug, currentUser)
     }
 
+    const mdblistCollectionUrl = mdblistCollectionUrlForId(id)
+    if (mdblistCollectionUrl) {
+      const entry = config.mdblistLists.find(e => e.url === mdblistCollectionUrl)
+      if (entry) return buildMdblistCollectionItem(entry, mdblistFolderMembers(currentUser, mdblistCollectionUrl).length)
+    }
+
     const mdblistUrl = mdblistFolderUrlForId(id)
     if (mdblistUrl) {
-      const entry = config.mdblistLists.find(e => e.url === mdblistUrl)
-      if (entry?.mode === 'collection') {
-        return buildMdblistCollectionItem(entry, mdblistFolderMembers(currentUser, mdblistUrl).length)
-      }
       return buildMdblistFolderItem(mdblistUrl, mdblistFolderMembers(currentUser, mdblistUrl).length)
     }
 
@@ -3125,11 +3216,19 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       return sendImageUrl(reply, headers, representative.path, representative.kind, query)
     }
 
+    const folderSlug = idToTraktFolderSlug(id)
+    if (folderSlug && isTraktEntryVisible(folderSlug)) {
+      return sendTraktCollectionImage(folderSlug, type, query, headers, reply)
+    }
     const collectionSlug = idToTraktCollectionSlug(id)
-    if (collectionSlug && (isTraktEntryCollection(collectionSlug) || isTraktEntryVisible(collectionSlug))) {
+    if (collectionSlug && isTraktEntryCollection(collectionSlug)) {
       return sendTraktCollectionImage(collectionSlug, type, query, headers, reply)
     }
 
+    const mdblistCollectionImageUrl = mdblistCollectionUrlForId(id)
+    if (mdblistCollectionImageUrl) {
+      return sendMdblistFolderImage(mdblistCollectionImageUrl, type, query, headers, reply)
+    }
     const mdblistImageUrl = mdblistFolderUrlForId(id)
     if (mdblistImageUrl) {
       return sendMdblistFolderImage(mdblistImageUrl, type, query, headers, reply)

--- a/src/mdblist.ts
+++ b/src/mdblist.ts
@@ -1,11 +1,11 @@
-import { config, type MdblistListEntry } from './config.js'
+import { config, normalizeListPresentation, presentationFromLegacyMode, type MdblistListEntry } from './config.js'
 import {
   hasAnySourceItem,
   listSourceKeys,
   pruneOrphanedMovies,
   pruneOrphanedShows,
   removeSourceKey,
-  replaceSourceItems,
+  replaceSourceItemsWithPositions,
   upsertManualShowSubscription,
   type MediaType,
 } from './db.js'
@@ -17,6 +17,7 @@ const MDBLIST_WEB_ORIGIN = 'https://mdblist.com'
 interface MdblistEntry {
   tmdbId: number
   mediaType: MediaType
+  rank?: number
 }
 
 interface MdblistFetchResult {
@@ -69,7 +70,7 @@ export function normalizeMdblistListUrl(value: string): string {
     throw new Error(`MDBList URL is missing a list path: ${raw}`)
   }
 
-  return `${MDBLIST_WEB_ORIGIN}/lists/${listPath}`
+  return `${MDBLIST_WEB_ORIGIN}/lists/${listPath}${parsed.search}`
 }
 
 export function normalizeMdblistListUrls(values: string[]): string[] {
@@ -95,7 +96,16 @@ export function normalizeMdblistEntries(entries: MdblistListEntry[]): MdblistLis
       const url = normalizeMdblistListUrl(entry.url)
       if (!seen.has(url)) {
         seen.add(url)
-        result.push({ url, ...(entry.name?.trim() ? { name: entry.name.trim() } : {}) })
+        const hasPresentation = entry.includeInLibrary != null || entry.showAsFolder != null || entry.showAsCollection != null
+        const presentation = hasPresentation
+          ? normalizeListPresentation(entry)
+          : presentationFromLegacyMode(entry.mode)
+        result.push({
+          url,
+          ...(entry.name?.trim() ? { name: entry.name.trim() } : {}),
+          ...(presentation ? presentation : {}),
+          ...(Number.isFinite(Number(entry.maxItems)) && Number(entry.maxItems) > 0 ? { maxItems: Math.trunc(Number(entry.maxItems)) } : {}),
+        })
       }
     } catch { /* skip invalid URLs */ }
   }
@@ -199,14 +209,71 @@ function extractPublicListEntries(html: string): MdblistEntry[] {
 }
 
 interface MdblistApiItem {
+  id?: number
+  rank?: number
+  mediatype?: string
   ids?: { tmdb?: number }
 }
 
+type MdblistApiEndpoint = {
+  url: URL
+  responseKind: 'standard-list' | 'justwatch-chart'
+}
+
+function mdblistApiItemsRequest(listUrl: string, limit: number, offset: number, apiKey: string): MdblistApiEndpoint {
+  const normalized = normalizeMdblistListUrl(listUrl)
+  const input = new URL(normalized)
+  const parts = input.pathname.split('/').filter(Boolean)
+  const mediaMap: Record<string, MediaType> = {
+    movies: 'movie',
+    shows: 'show',
+  }
+
+  if (parts[0] !== 'lists') {
+    throw new Error('Unsupported MDBList URL')
+  }
+
+  if (parts[1] === 'official' && mediaMap[parts[2]]) {
+    const mediaType = mediaMap[parts[2]]
+    const slug = parts[3]
+    if (!slug) throw new Error('Unsupported MDBList official list URL')
+
+    if (slug === 'justwatch-streaming-charts') {
+      const output = new URL(`https://api.mdblist.com/justwatch/streaming-charts/${mediaType}`)
+      for (const name of ['locale', 'country', 'rank', 'period', 'provider', 'genre', 'subgenre', 'x']) {
+        const value = input.searchParams.get(name)
+        if (value !== null) output.searchParams.set(name, value)
+      }
+      if (!output.searchParams.has('x')) output.searchParams.set('x', '20')
+      output.searchParams.set('apikey', apiKey)
+      return { url: output, responseKind: 'justwatch-chart' }
+    }
+
+    const apiSlug = slug === 'streaming-charts' ? 'justwatch-streaming-charts' : slug
+    const output = new URL(`https://api.mdblist.com/lists/official/${apiSlug}/items`)
+    output.searchParams.set('limit', String(limit))
+    output.searchParams.set('offset', String(offset))
+    output.searchParams.set('mediatype', mediaType)
+    output.searchParams.set('apikey', apiKey)
+    return { url: output, responseKind: 'standard-list' }
+  }
+
+  if (parts.length === 3) {
+    const [, username, slug] = parts
+    const output = new URL(`https://api.mdblist.com/lists/${username}/${slug}/items`)
+    output.searchParams.set('limit', String(limit))
+    output.searchParams.set('offset', String(offset))
+    output.searchParams.set('apikey', apiKey)
+    return { url: output, responseKind: 'standard-list' }
+  }
+
+  throw new Error('Unsupported MDBList list URL')
+}
+
 async function fetchApiListEntries(listUrl: string, apiKey: string, maxEntries: number): Promise<MdblistFetchResult> {
-  const path = mdblistListPathFromUrl(listUrl)
   const entries: MdblistEntry[] = []
   const seen = new Set<string>()
-  const limit = 100
+  const limit = Math.max(1, Math.min(100, maxEntries))
   let offset = 0
   let capped = false
 
@@ -219,10 +286,10 @@ async function fetchApiListEntries(listUrl: string, apiKey: string, maxEntries: 
   }
 
   while (true) {
-    const url = `https://api.mdblist.com/lists/${path}/items?limit=${limit}&offset=${offset}&apikey=${encodeURIComponent(apiKey)}`
+    const request = mdblistApiItemsRequest(listUrl, limit, offset, apiKey)
     let res: Response
     try {
-      res = await fetch(url, {
+      res = await fetch(request.url, {
         headers: { 'User-Agent': 'fetcherr/1.0' },
         signal: AbortSignal.timeout(20_000),
       })
@@ -233,19 +300,29 @@ async function fetchApiListEntries(listUrl: string, apiKey: string, maxEntries: 
       const body = await res.text().catch(() => '')
       throw new Error(`MDBList API ${res.status}: ${body.slice(0, 200)}`)
     }
-    const data = await res.json() as { movies?: MdblistApiItem[]; shows?: MdblistApiItem[] }
+        const data = await res.json() as { movies?: MdblistApiItem[]; shows?: MdblistApiItem[]; results?: MdblistApiItem[]; media_type?: string }
+    if (request.responseKind === 'justwatch-chart') {
+      const mediaType: MediaType = data.media_type === 'show' ? 'show' : 'movie'
+      for (const item of data.results ?? []) {
+        const tmdbId = item.ids?.tmdb ?? item.id
+        if (!tmdbId || !Number.isFinite(tmdbId) || tmdbId <= 0) continue
+        addEntry({ tmdbId, mediaType, rank: item.rank })
+      }
+      break
+    }
+
     const pageMovies = data.movies ?? []
     const pageShows = data.shows ?? []
 
     for (const item of pageMovies) {
-      const tmdbId = item.ids?.tmdb
+      const tmdbId = item.ids?.tmdb ?? item.id
       if (!tmdbId || !Number.isFinite(tmdbId) || tmdbId <= 0) continue
-      addEntry({ tmdbId, mediaType: 'movie' })
+      addEntry({ tmdbId, mediaType: 'movie', rank: item.rank })
     }
     for (const item of pageShows) {
-      const tmdbId = item.ids?.tmdb
+      const tmdbId = item.ids?.tmdb ?? item.id
       if (!tmdbId || !Number.isFinite(tmdbId) || tmdbId <= 0) continue
-      addEntry({ tmdbId, mediaType: 'show' })
+      addEntry({ tmdbId, mediaType: 'show', rank: item.rank })
     }
 
     if (entries.length >= maxEntries) break
@@ -286,30 +363,32 @@ export async function syncMdblistList(listUrl: string): Promise<MdblistListSyncR
   }
 
   console.log(`mdblist: syncing ${normalizedUrl}`)
-  const maxItems = Math.max(1, config.mdblistMaxItems)
+  const configuredEntry = config.mdblistLists.find(entry => normalizeMdblistListUrl(entry.url) === normalizedUrl)
+  const maxItems = Math.max(1, configuredEntry?.maxItems ?? config.mdblistMaxItems)
   const { entries, capped, discoveredTotal } = await fetchMdblistEntries(normalizedUrl, maxItems)
   if (capped) {
     const totalLabel = discoveredTotal ? `${discoveredTotal} public TMDB links` : `at least ${entries.length} API items`
     console.warn(`mdblist: ${normalizedUrl} has ${totalLabel}; importing first ${entries.length}. Set MDBLIST_MAX_ITEMS to adjust this cap.`)
   } else {
-    console.log(`mdblist: ${normalizedUrl} has ${entries.length} public TMDB links`)
+    console.log(`mdblist: ${normalizedUrl} has ${entries.length} items`)
   }
 
   let movies = 0
   let shows = 0
-  const movieTmdbIds: number[] = []
-  const showTmdbIds: number[] = []
+  const movieSourceItems: Array<{ tmdbId: number; sourcePosition: number }> = []
+  const showSourceItems: Array<{ tmdbId: number; sourcePosition: number }> = []
 
-  for (const entry of entries) {
+  for (const [idx, entry] of entries.entries()) {
+    const sourcePosition = entry.rank && Number.isFinite(entry.rank) && entry.rank > 0 ? Math.trunc(entry.rank) : idx + 1
     if (entry.mediaType === 'movie') {
-      movieTmdbIds.push(entry.tmdbId)
+      movieSourceItems.push({ tmdbId: entry.tmdbId, sourcePosition })
       const movie = await fetchMovieByTmdbId(entry.tmdbId)
       if (movie) movies++
       continue
     }
 
     const isNewToLibrary = !hasAnySourceItem('show', entry.tmdbId)
-    showTmdbIds.push(entry.tmdbId)
+    showSourceItems.push({ tmdbId: entry.tmdbId, sourcePosition })
     const show = await fetchShowByTmdbId(entry.tmdbId)
     if (show && isNewToLibrary && config.showAddDefaultMode === 'latest') {
       upsertManualShowSubscription(entry.tmdbId, 'latest', 0)
@@ -317,8 +396,8 @@ export async function syncMdblistList(listUrl: string): Promise<MdblistListSyncR
     if (show) shows++
   }
 
-  const removedMovies = replaceSourceItems(sourceKey, 'movie', movieTmdbIds)
-  const removedShows = replaceSourceItems(sourceKey, 'show', showTmdbIds)
+  const removedMovies = replaceSourceItemsWithPositions(sourceKey, 'movie', movieSourceItems)
+  const removedShows = replaceSourceItemsWithPositions(sourceKey, 'show', showSourceItems)
   const prunedMovies = pruneOrphanedMovies(removedMovies)
   const prunedShows = pruneOrphanedShows(removedShows)
 

--- a/src/ui/routes.ts
+++ b/src/ui/routes.ts
@@ -22,7 +22,7 @@ import {
   getSessionCookie, clearSessionCookie, getTokenFromCookie,
 } from './auth.js'
 import { config } from '../config.js'
-import { collectStreamProviderUrls, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseFoldersSetting, serializeFoldersSetting, parseEnglishStreamMode, parseMdblistLists, parseMediaSourceLimit, parseMovieReleaseMode, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseStremioSearchSource, parseTraktLists } from '../config.js'
+import { collectStreamProviderUrls, normalizeListPresentation, normalizeSootioUrl, parseAudioLanguage, parseBooleanSetting, parseFoldersSetting, serializeFoldersSetting, parseEnglishStreamMode, parseMdblistLists, parseMediaSourceLimit, parseMovieReleaseMode, parseShowAddDefaultMode, parseStreamProviderUrls, parseStreamRankingMode, parseStremioSearchSource, parseTraktLists, type ListPresentation } from '../config.js'
 import { fetchMovieByTmdbId, fetchMovieCollection, fetchShowByTmdbId, ensureShowSeasonsCached } from '../tmdb.js'
 import { cleanupRemovedTraktListSources, fetchTraktUserLists } from '../trakt.js'
 import { cleanupRemovedMdblistListSources, normalizeMdblistEntries } from '../mdblist.js'
@@ -944,24 +944,29 @@ export async function uiRoutes(app: FastifyInstance) {
       cleanupRemovedTraktListSources(lists)
     }
     if (body.traktListModes != null && typeof body.traktListModes === 'object' && !Array.isArray(body.traktListModes)) {
-      const MODES = new Set(['library', 'folder', 'collection', 'browse_only'])
-      const modes: Record<string, string> = {}
+      const modes: Record<string, ListPresentation> = {}
       for (const [k, v] of Object.entries(body.traktListModes as Record<string, unknown>)) {
-        if (typeof v === 'string' && MODES.has(v) && v !== 'library') modes[k] = v
+        if (typeof v === 'string' || (typeof v === 'object' && v !== null && !Array.isArray(v))) {
+          modes[k] = normalizeListPresentation(v)
+        }
       }
       setSetting('traktListModes', JSON.stringify(modes))
-      config.traktListModes = modes as Record<string, import('../config.js').TraktListMode>
+      config.traktListModes = modes
     }
     if (Array.isArray(body.mdblistLists)) {
       try {
-        const MODES = new Set(['library', 'folder', 'collection', 'browse_only'])
         const raw = (body.mdblistLists as unknown[])
           .filter((v): v is Record<string, unknown> => typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).url === 'string')
-          .map(v => ({
-            url: String(v.url).trim(),
-            ...(v.name && String(v.name).trim() ? { name: String(v.name).trim() } : {}),
-            ...(typeof v.mode === 'string' && MODES.has(v.mode) ? { mode: v.mode as 'library' | 'folder' | 'collection' | 'browse_only' } : {}),
-          }))
+          .map(v => {
+            const maxItems = Number(v.maxItems)
+            const presentation = normalizeListPresentation(v)
+            return {
+              url: String(v.url).trim(),
+              ...(v.name && String(v.name).trim() ? { name: String(v.name).trim() } : {}),
+              ...presentation,
+              ...(Number.isFinite(maxItems) && maxItems > 0 ? { maxItems: Math.trunc(maxItems) } : {}),
+            }
+          })
         const entries = normalizeMdblistEntries(raw)
         setSetting('mdblistLists', JSON.stringify(entries))
         config.mdblistLists = entries

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -298,16 +298,16 @@
   <!-- MDBList -->
   <section class="section" id="mdblist">
     <div class="section-title">MDBList</div>
-    <div class="field-note trakt-list-note">Public MDBList URLs synced with your library. Use the ⋮ menu on each list to control how it appears: as a folder, collection, or browse-only (visible in Infuse but excluded from the main library).</div>
+    <div class="field-note trakt-list-note">Public MDBList URLs synced with Fetcherr. Use the ⋮ menu on each list to choose any combination of appearing in Movies/Shows, as a top-level Folder, and as a Collection.</div>
     <div class="btn-row trakt-list-actions">
       <a class="btn btn-sm" href="https://mdblist.com/toplists/" target="_blank" rel="noreferrer">Browse Top Lists</a>
     </div>
     <div class="field">
-      <label for="mdblistApiKey">API Key <span class="optional-tag">Optional</span> <span id="mdblistConfigState" class="config-state" hidden></span></label>
+      <label for="mdblistApiKey">API Key <span class="optional-tag">Required</span> <span id="mdblistConfigState" class="config-state" hidden></span></label>
       <div class="input-row">
         <input id="mdblistApiKey" type="password" placeholder="Enter your MDBList API key" oninput="setMdblistStoredStatus()">
       </div>
-      <div class="field-note">Required for lists with more than 48 items. Get your free key at <a href="https://mdblist.com/preferences/" target="_blank" rel="noreferrer">mdblist.com/preferences</a>.</div>
+      <div class="field-note">Required for reliable MDBList sync, including official lists and streaming charts. Get your free key at <a href="https://mdblist.com/preferences/" target="_blank" rel="noreferrer">mdblist.com/preferences</a>.</div>
     </div>
     <div class="field">
       <label>Lists</label>
@@ -394,6 +394,11 @@
         <label for="mdblistEditName">Name <span class="optional-tag">Optional</span></label>
         <input id="mdblistEditName" type="text" placeholder="Custom display name">
         <div class="field-note">Overrides the MDBList name in Infuse and VidHub.</div>
+      </div>
+      <div class="field">
+        <label for="mdblistEditMaxItems">Max Items <span class="optional-tag">Optional</span></label>
+        <input id="mdblistEditMaxItems" type="number" min="1" step="1" placeholder="Use global default">
+        <div class="field-note">Limits this list during sync. Leave blank to use the global MDBList cap.</div>
       </div>
     </div>
     <div class="modal-actions">
@@ -765,7 +770,68 @@
     } catch { return entry.url }
   }
 
-  const MDBLIST_MODE_LABELS = { library: 'Library', folder: 'Folder', collection: 'Collection', browse_only: 'Browse Only' }
+  const LIST_PRESENTATION_OPTIONS = [
+    ['includeInLibrary', 'Movies/Shows', 'Include items in the main Movies or Shows source.'],
+    ['showAsFolder', 'Folder', 'Show this list as a folder at the Fetch root.'],
+    ['showAsCollection', 'Collection', 'Show this list under Fetch → Collections.'],
+  ]
+  const LEGACY_LIST_PRESENTATIONS = {
+    library: { includeInLibrary: true, showAsFolder: false, showAsCollection: false },
+    folder: { includeInLibrary: true, showAsFolder: true, showAsCollection: false },
+    browse_only: { includeInLibrary: false, showAsFolder: true, showAsCollection: false },
+    collection: { includeInLibrary: true, showAsFolder: false, showAsCollection: true },
+  }
+
+  function listPresentation(entry) {
+    const legacy = entry?.mode && LEGACY_LIST_PRESENTATIONS[entry.mode]
+    return {
+      includeInLibrary: typeof entry?.includeInLibrary === 'boolean' ? entry.includeInLibrary : (legacy ? legacy.includeInLibrary : true),
+      showAsFolder: typeof entry?.showAsFolder === 'boolean' ? entry.showAsFolder : (legacy ? legacy.showAsFolder : false),
+      showAsCollection: typeof entry?.showAsCollection === 'boolean' ? entry.showAsCollection : (legacy ? legacy.showAsCollection : false),
+    }
+  }
+
+  function withListPresentation(entry) {
+    const { mode, ...rest } = entry || {}
+    return { ...rest, ...listPresentation(entry) }
+  }
+
+  function listPresentationChips(entry) {
+    const p = listPresentation(entry)
+    const chips = LIST_PRESENTATION_OPTIONS
+      .filter(([key]) => p[key])
+      .map(([key, label, title]) => `<span class="mdblist-mode-badge mdblist-mode-${key}" title="${_esc(title)}">${label}</span>`)
+    if (!chips.length) {
+      chips.push('<span class="mdblist-mode-badge mdblist-mode-disabled" title="This list is saved but is not currently used.">Disabled</span>')
+    }
+    return chips.join('')
+  }
+
+  function listPresentationMenu(kind, id, entry) {
+    const p = listPresentation(entry)
+    const rows = LIST_PRESENTATION_OPTIONS.map(([key, label, title]) => {
+      const next = p[key] ? 'false' : 'true'
+      const handler = kind === 'mdblist'
+        ? `toggleMdblistPresentation(${id}, '${key}', ${next})`
+        : `toggleTraktPresentation('${_esc(String(id))}', '${key}', ${next})`
+      return `<div class="mdblist-menu-check" role="checkbox" aria-checked="${p[key] ? 'true' : 'false'}" tabindex="0" title="${_esc(title)}" onclick="event.preventDefault(); event.stopPropagation(); ${handler}" onkeydown="if (event.key === ' ' || event.key === 'Enter') { event.preventDefault(); event.stopPropagation(); ${handler} }">
+        <input type="checkbox" tabindex="-1" ${p[key] ? 'checked' : ''} aria-hidden="true">
+        <span>${label}</span>
+      </div>`
+    }).join('')
+    return `<div class="mdblist-menu-heading">Show list as:</div>${rows}`
+  }
+
+  function normalizeMdblistUrl(value) {
+    const raw = String(value || '').trim()
+    if (!raw) return ''
+    try {
+      const url = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`)
+      const host = url.hostname.toLowerCase()
+      if (host !== 'mdblist.com' && host !== 'www.mdblist.com') return raw
+      return `https://mdblist.com${url.pathname.replace(/\/+$/, '')}${url.search}`
+    } catch { return raw }
+  }
 
   function renderMdblistRows() {
     const container = document.getElementById('mdblistRows')
@@ -774,20 +840,15 @@
       return
     }
     container.innerHTML = mdblistEntries.map((entry, idx) => {
-      const mode = entry.mode || 'library'
-      const badge = mode !== 'library' ? `<span class="mdblist-mode-badge mdblist-mode-${mode}">${MDBLIST_MODE_LABELS[mode]}</span>` : ''
       const isOpen = mdblistOpenMenuIdx === idx
       return `<div class="mdblist-row">
-        <div class="mdblist-name">${_esc(mdblistDisplayName(entry))}${badge}</div>
+        <div class="mdblist-name">${_esc(mdblistDisplayName(entry))}${listPresentationChips(entry)}</div>
         <div class="mdblist-row-menu${isOpen ? ' open' : ''}" id="mdblist-menu-${idx}">
           <button type="button" class="mdblist-menu-trigger btn-icon" title="List options" aria-label="List options" onclick="toggleMdblistMenu(${idx}, event)">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
           </button>
           <div class="mdblist-menu-dropdown">
-            <div class="mdblist-menu-item${mode === 'library' ? ' checked' : ''}" onclick="setMdblistMode(${idx}, 'library')">Library</div>
-            <div class="mdblist-menu-item${mode === 'folder' ? ' checked' : ''}" onclick="setMdblistMode(${idx}, 'folder')">Add as Folder</div>
-            <div class="mdblist-menu-item${mode === 'collection' ? ' checked' : ''}" onclick="setMdblistMode(${idx}, 'collection')">Add as Collection</div>
-            <div class="mdblist-menu-item${mode === 'browse_only' ? ' checked' : ''}" onclick="setMdblistMode(${idx}, 'browse_only')">Browse Only</div>
+            ${listPresentationMenu('mdblist', idx, entry)}
             <div class="mdblist-menu-divider"></div>
             <div class="mdblist-menu-item" onclick="openMdblistEditModal(${idx}); closeMdblistMenus()">Edit</div>
             <div class="mdblist-menu-item mdblist-menu-danger" onclick="removeMdblistEntry(${idx})">Remove</div>
@@ -807,9 +868,8 @@
     if (mdblistOpenMenuIdx !== -1) { mdblistOpenMenuIdx = -1; renderMdblistRows() }
   }
 
-  function setMdblistMode(idx, mode) {
-    mdblistEntries = mdblistEntries.map((e, i) => i === idx ? { ...e, mode: mode === 'library' ? undefined : mode } : e)
-    mdblistOpenMenuIdx = -1
+  function toggleMdblistPresentation(idx, key, enabled) {
+    mdblistEntries = mdblistEntries.map((e, i) => i === idx ? { ...withListPresentation(e), [key]: enabled } : e)
     renderMdblistRows()
     _markDirty()
   }
@@ -834,7 +894,7 @@
 
   function addMdblistEntry() {
     const input = document.getElementById('mdblistAddInput')
-    const url = input.value.trim()
+    const url = normalizeMdblistUrl(input.value)
     if (!url) return
     if (!url.includes('mdblist.com/lists/')) {
       showOut('Enter a valid MDBList list URL (mdblist.com/lists/…)', 'error')
@@ -866,8 +926,10 @@
     const entry = mdblistEntries[idx]
     document.getElementById('mdblistEditUrl').value = entry.url
     document.getElementById('mdblistEditName').value = entry.name || ''
+    document.getElementById('mdblistEditMaxItems').value = entry.maxItems || ''
     document.getElementById('mdblistEditModalBackdrop').classList.add('open')
     document.addEventListener('keydown', onMdblistEditModalKey)
+    document.getElementById('mdblistEditUrl').focus()
   }
 
   function closeMdblistEditModal(e) {
@@ -882,17 +944,27 @@
   }
 
   function saveMdblistEdit() {
-    const url = document.getElementById('mdblistEditUrl').value.trim()
+    const url = normalizeMdblistUrl(document.getElementById('mdblistEditUrl').value)
     const name = document.getElementById('mdblistEditName').value.trim()
+    const maxItemsRaw = document.getElementById('mdblistEditMaxItems').value.trim()
+    const maxItems = maxItemsRaw ? Number(maxItemsRaw) : 0
     if (!url) return
     if (!url.includes('mdblist.com/lists/')) {
       showOut('Enter a valid MDBList list URL (mdblist.com/lists/…)', 'error')
       return
     }
+    if (mdblistEntries.some((e, i) => i !== mdblistEditIdx && e.url === url)) {
+      showOut('This list is already added.', 'error')
+      return
+    }
+    if (maxItemsRaw && (!Number.isInteger(maxItems) || maxItems <= 0)) {
+      showOut('Max Items must be a positive number.', 'error')
+      return
+    }
     if (mdblistEditIdx >= 0 && mdblistEditIdx < mdblistEntries.length) {
       const existing = mdblistEntries[mdblistEditIdx]
       mdblistEntries = mdblistEntries.map((e, i) => i === mdblistEditIdx
-        ? { url, ...(name ? { name } : {}), ...(existing.mode ? { mode: existing.mode } : {}) }
+        ? { url, ...(name ? { name } : {}), ...listPresentation(existing), ...(maxItemsRaw ? { maxItems } : {}) }
         : e)
       renderMdblistRows()
       _markDirty()
@@ -956,31 +1028,41 @@
     document.getElementById('traktWatchlistShows').checked = d.traktWatchlistShows !== false
     document.getElementById('traktWatchHistory').checked = d.traktWatchHistory === true
     if (d.traktListModes && typeof d.traktListModes === 'object') {
-      traktListModes = { ...d.traktListModes }
+      traktListModes = Object.fromEntries(Object.entries(d.traktListModes).map(([slug, value]) => [slug, listPresentation(value)]))
     } else {
-      // Migrate legacy traktFolders/traktCollections → per-list modes
+      // Migrate legacy traktFolders/traktCollections → per-list presentations.
       traktListModes = {}
       if (d.traktCollections) {
-        for (const slug of (Array.isArray(d.traktLists) ? d.traktLists : [])) traktListModes[slug] = 'collection'
+        for (const slug of (Array.isArray(d.traktLists) ? d.traktLists : [])) traktListModes[slug] = { includeInLibrary: true, showAsFolder: false, showAsCollection: true }
       } else if (d.traktFolders === true) {
-        for (const slug of (Array.isArray(d.traktLists) ? d.traktLists : [])) traktListModes[slug] = 'folder'
+        for (const slug of (Array.isArray(d.traktLists) ? d.traktLists : [])) traktListModes[slug] = { includeInLibrary: true, showAsFolder: true, showAsCollection: false }
       } else if (Array.isArray(d.traktFolders)) {
         for (const slug of (Array.isArray(d.traktLists) ? d.traktLists : [])) {
-          if (d.traktFolders.some(s => slug === s || slug.endsWith('/' + s))) traktListModes[slug] = 'folder'
+          if (d.traktFolders.some(s => slug === s || slug.endsWith('/' + s))) traktListModes[slug] = { includeInLibrary: true, showAsFolder: true, showAsCollection: false }
         }
       }
     }
     document.getElementById('torBoxCleanupEnabled').checked = d.torBoxCleanupEnabled !== false
     setSecretPlaceholder('mdblistApiKey', hasStoredMdblistApiKey, 'Enter your MDBList API key')
-    mdblistEntries = Array.isArray(d.mdblistLists) ? d.mdblistLists.map(e => {
-      // Migrate legacy mdblistFolders setting: if no mode set but entry's path is in mdblistFolders, mark as folder
-      if (!e.mode && Array.isArray(d.mdblistFolders)) {
-        const p = mdblistPathFromUrl(e.url)
-        if (d.mdblistFolders.some(s => p === s || p.endsWith('/' + s))) return { ...e, mode: 'folder' }
-      }
-      if (!e.mode && d.mdblistFolders === true) return { ...e, mode: 'folder' }
-      return e
-    }) : []
+    mdblistEntries = Array.isArray(d.mdblistLists)
+      ? d.mdblistLists.map(entry => ({
+          ...entry,
+          url: normalizeMdblistUrl(entry.url),
+        })).filter(entry => entry.url).map(entry => {
+          let e = withListPresentation(entry)
+          const hasExplicitPresentation = typeof entry.includeInLibrary === 'boolean'
+            || typeof entry.showAsFolder === 'boolean'
+            || typeof entry.showAsCollection === 'boolean'
+            || !!entry.mode
+          // Migrate legacy mdblistFolders setting when no explicit list presentation exists.
+          if (!hasExplicitPresentation && Array.isArray(d.mdblistFolders)) {
+            const p = mdblistPathFromUrl(e.url)
+            if (d.mdblistFolders.some(s => p === s || p.endsWith('/' + s))) e = { ...e, showAsFolder: true }
+          }
+          if (!hasExplicitPresentation && d.mdblistFolders === true) e = { ...e, showAsFolder: true }
+          return e
+        })
+      : []
     renderMdblistRows()
     selectedTraktLists = Array.isArray(d.traktLists) ? d.traktLists : []
     managedUsers = Array.isArray(d.users) ? d.users.map(user => ({ ...user, pendingPassword: '' })) : []
@@ -1259,14 +1341,13 @@
     const el = document.getElementById('traktLists')
     if (!traktListsData.length) return
     el.innerHTML = traktListsData.map(list => {
-      const mode = traktListModes[list.slug] || 'library'
-      const badge = mode !== 'library' ? `<span class="mdblist-mode-badge mdblist-mode-${mode}">${MDBLIST_MODE_LABELS[mode]}</span>` : ''
+      const presentation = listPresentation(traktListModes[list.slug] || {})
       const isOpen = traktOpenMenuSlug === list.slug
       const safeId = list.slug.replace(/\//g, '-')
       return `<label class="check-item">
         <input type="checkbox" value="${_esc(list.slug)}" ${selectedTraktLists.includes(list.slug) ? 'checked' : ''} onchange="toggleTraktList(this)">
         <div class="check-meta">
-          <div class="check-title">${_esc(list.name)}${badge}</div>
+          <div class="check-title">${_esc(list.name)}${listPresentationChips(presentation)}</div>
           <div class="check-slug">${_esc(list.slug)}</div>
         </div>
         <div class="mdblist-row-menu${isOpen ? ' open' : ''}" id="trakt-menu-${safeId}">
@@ -1274,10 +1355,7 @@
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
           </button>
           <div class="mdblist-menu-dropdown">
-            <div class="mdblist-menu-item${mode === 'library' ? ' checked' : ''}" onclick="event.preventDefault(); event.stopPropagation(); setTraktListMode('${_esc(list.slug)}', 'library')">Library</div>
-            <div class="mdblist-menu-item${mode === 'folder' ? ' checked' : ''}" onclick="event.preventDefault(); event.stopPropagation(); setTraktListMode('${_esc(list.slug)}', 'folder')">Add as Folder</div>
-            <div class="mdblist-menu-item${mode === 'collection' ? ' checked' : ''}" onclick="event.preventDefault(); event.stopPropagation(); setTraktListMode('${_esc(list.slug)}', 'collection')">Add as Collection</div>
-            <div class="mdblist-menu-item${mode === 'browse_only' ? ' checked' : ''}" onclick="event.preventDefault(); event.stopPropagation(); setTraktListMode('${_esc(list.slug)}', 'browse_only')">Browse Only</div>
+            ${listPresentationMenu('trakt', list.slug, presentation)}
           </div>
         </div>
       </label>`
@@ -1314,9 +1392,8 @@
     renderTraktLists()
   }
 
-  function setTraktListMode(slug, mode) {
-    if (mode === 'library') { delete traktListModes[slug] } else { traktListModes[slug] = mode }
-    traktOpenMenuSlug = null
+  function toggleTraktPresentation(slug, key, enabled) {
+    traktListModes[slug] = { ...listPresentation(traktListModes[slug] || {}), [key]: enabled }
     renderTraktLists()
     _markDirty()
   }

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -411,7 +411,7 @@ input,
 select,
 textarea {
   width: 100%;
-  padding: 12px 12px;
+  padding: 14px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-inset);
@@ -445,7 +445,7 @@ input:-webkit-autofill:focus {
 }
 
 select {
-  min-height: 45px;
+  min-height: 52px;
   cursor: pointer;
 }
 
@@ -996,8 +996,8 @@ label {
 }
 
 .detail-mode-options .item-mode-btn {
-  min-height: 40px;
-  padding: 9px 12px;
+  min-height: 44px;
+  padding: 11px 12px;
 }
 
 .item-mode-btn:hover,
@@ -1154,8 +1154,8 @@ label {
   align-items: center;
   gap: 8px;
   width: 100%;
-  min-height: 42px;
-  padding: 11px 11px;
+  min-height: 46px;
+  padding: 13px 11px;
   border: 1px solid transparent;
   border-radius: var(--radius);
   background: transparent;

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -411,12 +411,13 @@ input,
 select,
 textarea {
   width: 100%;
-  padding: 10px 12px;
+  padding: 12px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-inset);
   color: var(--text);
   font-size: 14px;
+  line-height: 1.35;
   outline: none;
   box-shadow: inset 0 1px 0 rgba(255,255,255,.025);
   transition: border-color .15s, box-shadow .15s, background .15s;
@@ -444,10 +445,13 @@ input:-webkit-autofill:focus {
 }
 
 select {
+  min-height: 45px;
   cursor: pointer;
 }
 
 select option {
+  min-height: 34px;
+  padding: 8px 12px;
   background: var(--surface);
 }
 
@@ -976,7 +980,8 @@ label {
 }
 
 .item-mode-btn {
-  padding: 6px 8px;
+  padding: 8px 10px;
+  line-height: 1.25;
   white-space: nowrap;
 }
 
@@ -991,8 +996,8 @@ label {
 }
 
 .detail-mode-options .item-mode-btn {
-  min-height: 34px;
-  padding: 7px 10px;
+  min-height: 40px;
+  padding: 9px 12px;
 }
 
 .item-mode-btn:hover,
@@ -1149,8 +1154,8 @@ label {
   align-items: center;
   gap: 8px;
   width: 100%;
-  min-height: 34px;
-  padding: 8px 9px;
+  min-height: 42px;
+  padding: 11px 11px;
   border: 1px solid transparent;
   border-radius: var(--radius);
   background: transparent;
@@ -1158,6 +1163,7 @@ label {
   font-family: inherit;
   font-size: 12px;
   font-weight: 700;
+  line-height: 1.25;
   text-align: left;
   cursor: pointer;
   transition: background .15s, border-color .15s, color .15s;

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -411,7 +411,7 @@ input,
 select,
 textarea {
   width: 100%;
-  padding: 14px 12px;
+  padding: .75rem .857rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-inset);
@@ -447,12 +447,12 @@ input:-webkit-autofill:focus {
 select {
   -webkit-appearance: none;
   appearance: none;
-  height: 52px;
-  min-height: 52px;
-  padding: 0 40px 0 12px;
+  height: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0 2.75rem 0 .857rem;
   background:
-    linear-gradient(45deg, transparent 50%, var(--muted-strong) 50%) calc(100% - 20px) 50% / 6px 6px no-repeat,
-    linear-gradient(135deg, var(--muted-strong) 50%, transparent 50%) calc(100% - 16px) 50% / 6px 6px no-repeat,
+    linear-gradient(45deg, transparent 50%, var(--muted-strong) 50%) calc(100% - 1.35rem) 50% / .43rem .43rem no-repeat,
+    linear-gradient(135deg, var(--muted-strong) 50%, transparent 50%) calc(100% - 1.1rem) 50% / .43rem .43rem no-repeat,
     var(--surface-inset);
   cursor: pointer;
 }
@@ -1004,9 +1004,9 @@ label {
 }
 
 .detail-mode-options .item-mode-btn {
-  height: 44px;
-  min-height: 44px;
-  padding: 11px 12px;
+  height: 2.85rem;
+  min-height: 2.85rem;
+  padding: .7rem .85rem;
 }
 
 .item-mode-btn:hover,
@@ -1163,9 +1163,9 @@ label {
   align-items: center;
   gap: 8px;
   width: 100%;
-  height: 46px;
-  min-height: 46px;
-  padding: 13px 11px;
+  height: 3rem;
+  min-height: 3rem;
+  padding: .8rem .75rem;
   border: 1px solid transparent;
   border-radius: var(--radius);
   background: transparent;

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -281,6 +281,10 @@ h1 {
   flex-wrap: wrap;
 }
 
+.btn-row {
+  margin-top: 12px;
+}
+
 .btn,
 .btn-add {
   display: inline-flex;
@@ -2119,7 +2123,7 @@ label {
   position: absolute;
   right: 0;
   top: calc(100% + 4px);
-  min-width: 168px;
+  min-width: 188px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -2134,8 +2138,9 @@ label {
 }
 
 .mdblist-menu-item {
-  padding: 7px 12px 7px 30px;
+  padding: 10px 14px 10px 32px;
   font-size: 13px;
+  line-height: 1.25;
   cursor: pointer;
   color: var(--text);
   position: relative;
@@ -2147,7 +2152,7 @@ label {
 }
 
 .mdblist-menu-heading {
-  padding: 8px 12px 4px;
+  padding: 10px 14px 6px;
   font-size: 11px;
   font-weight: 700;
   color: var(--muted);
@@ -2158,8 +2163,9 @@ label {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 12px;
+  padding: 10px 14px;
   font-size: 13px;
+  line-height: 1.25;
   cursor: pointer;
   color: var(--text);
   white-space: nowrap;
@@ -2179,7 +2185,7 @@ label {
 .mdblist-menu-item.checked::before {
   content: '✓';
   position: absolute;
-  left: 10px;
+  left: 12px;
   font-size: 11px;
   color: var(--accent);
 }

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -1900,6 +1900,25 @@ label {
   flex-shrink: 0;
 }
 
+.mdblist-row-actions .folder-toggle,
+.mdblist-row-actions .btn-icon,
+.mdblist-row-actions .btn-remove {
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+}
+
+.mdblist-row-actions .btn-icon,
+.mdblist-row-actions .btn-remove {
+  padding: 0;
+}
+
+.mdblist-row-actions .btn-icon svg,
+.mdblist-row-actions .btn-remove svg {
+  width: 13px;
+  height: 13px;
+}
+
 .mdblist-add-row {
   display: flex;
   gap: 8px;
@@ -2063,6 +2082,7 @@ label {
 
 .trakt-list-actions {
   margin-top: 12px;
+  margin-bottom: 14px;
 }
 
 /* MDBList three-dot menu */
@@ -2106,6 +2126,7 @@ label {
   box-shadow: 0 4px 16px rgba(0, 0, 0, .3);
   z-index: 200;
   overflow: hidden;
+  text-transform: none;
 }
 
 .mdblist-row-menu.open .mdblist-menu-dropdown {
@@ -2123,6 +2144,36 @@ label {
 
 .mdblist-menu-item:hover {
   background: var(--accent-dim);
+}
+
+.mdblist-menu-heading {
+  padding: 8px 12px 4px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--muted);
+  text-transform: none;
+}
+
+.mdblist-menu-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--text);
+  white-space: nowrap;
+  text-transform: none;
+}
+
+.mdblist-menu-check:hover {
+  background: var(--accent-dim);
+}
+
+.mdblist-menu-check input {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--accent);
 }
 
 .mdblist-menu-item.checked::before {
@@ -2168,11 +2219,18 @@ label {
   color: #e8890c;
 }
 
+.mdblist-mode-disabled {
+  background: rgba(150, 150, 150, .16);
+  color: var(--muted);
+}
+
 @media (prefers-color-scheme: light) {
   .mdblist-mode-browse_only { background: rgba(255, 140, 0, .12); color: #c06000; }
+  .mdblist-mode-disabled { background: rgba(80, 80, 80, .08); color: #707070; }
 }
 
 :root[data-theme="light"] .mdblist-mode-browse_only { background: rgba(255, 140, 0, .12); color: #c06000; }
+:root[data-theme="light"] .mdblist-mode-disabled { background: rgba(80, 80, 80, .08); color: #707070; }
 
 .user-table-wrap {
   margin-top: 14px;

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -445,7 +445,15 @@ input:-webkit-autofill:focus {
 }
 
 select {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 52px;
   min-height: 52px;
+  padding: 0 40px 0 12px;
+  background:
+    linear-gradient(45deg, transparent 50%, var(--muted-strong) 50%) calc(100% - 20px) 50% / 6px 6px no-repeat,
+    linear-gradient(135deg, var(--muted-strong) 50%, transparent 50%) calc(100% - 16px) 50% / 6px 6px no-repeat,
+    var(--surface-inset);
   cursor: pointer;
 }
 
@@ -996,6 +1004,7 @@ label {
 }
 
 .detail-mode-options .item-mode-btn {
+  height: 44px;
   min-height: 44px;
   padding: 11px 12px;
 }
@@ -1154,6 +1163,7 @@ label {
   align-items: center;
   gap: 8px;
   width: 100%;
+  height: 46px;
   min-height: 46px;
   padding: 13px 11px;
   border: 1px solid transparent;

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -2129,7 +2129,7 @@ label {
   position: absolute;
   right: 0;
   top: calc(100% + 4px);
-  min-width: 188px;
+  min-width: 168px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -2144,9 +2144,8 @@ label {
 }
 
 .mdblist-menu-item {
-  padding: 10px 14px 10px 32px;
+  padding: 7px 12px 7px 30px;
   font-size: 13px;
-  line-height: 1.25;
   cursor: pointer;
   color: var(--text);
   position: relative;
@@ -2158,7 +2157,7 @@ label {
 }
 
 .mdblist-menu-heading {
-  padding: 10px 14px 6px;
+  padding: 8px 12px 4px;
   font-size: 11px;
   font-weight: 700;
   color: var(--muted);
@@ -2169,9 +2168,8 @@ label {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 14px;
+  padding: 7px 12px;
   font-size: 13px;
-  line-height: 1.25;
   cursor: pointer;
   color: var(--text);
   white-space: nowrap;
@@ -2191,7 +2189,7 @@ label {
 .mdblist-menu-item.checked::before {
   content: '✓';
   position: absolute;
-  left: 12px;
+  left: 10px;
   font-size: 11px;
   color: var(--accent);
 }

--- a/src/ui/static/app.css
+++ b/src/ui/static/app.css
@@ -447,12 +447,11 @@ input:-webkit-autofill:focus {
 select {
   -webkit-appearance: none;
   appearance: none;
-  height: 2.75rem;
-  min-height: 2.75rem;
-  padding: 0 2.75rem 0 .857rem;
+  height: 2rem;
+  min-height: 2rem;
+  padding: 0 2rem 0 .75rem;
   background:
-    linear-gradient(45deg, transparent 50%, var(--muted-strong) 50%) calc(100% - 1.35rem) 50% / .43rem .43rem no-repeat,
-    linear-gradient(135deg, var(--muted-strong) 50%, transparent 50%) calc(100% - 1.1rem) 50% / .43rem .43rem no-repeat,
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1.25 6 6.25l5-5' fill='none' stroke='%23c2ccd9' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") calc(100% - .75rem) 50% / .75rem .5rem no-repeat,
     var(--surface-inset);
   cursor: pointer;
 }
@@ -1004,9 +1003,9 @@ label {
 }
 
 .detail-mode-options .item-mode-btn {
-  height: 2.85rem;
-  min-height: 2.85rem;
-  padding: .7rem .85rem;
+  height: 2rem;
+  min-height: 2rem;
+  padding: .35rem .75rem;
 }
 
 .item-mode-btn:hover,
@@ -1163,9 +1162,9 @@ label {
   align-items: center;
   gap: 8px;
   width: 100%;
-  height: 3rem;
-  min-height: 3rem;
-  padding: .8rem .75rem;
+  height: 2rem;
+  min-height: 2rem;
+  padding: .35rem .75rem;
   border: 1px solid transparent;
   border-radius: var(--radius);
   background: transparent;


### PR DESCRIPTION
## Summary
- Adds per-list presentation flags for Trakt and MDBList sources so lists can independently appear in Movies/Shows, as folders, and as collections.
- Keeps legacy list mode and folder settings migrating into the new presentation shape.
- Polishes Settings UI spacing, closed select/menu control sizing, and the native select chevron rendering.

## Impact
- Admin settings can configure richer list visibility without losing existing legacy configuration.
- Closed dropdown controls use rem-based heights and a clean SVG chevron while preserving native opened dropdown behavior.

## Validation
- npm run build
- docker build -t fetcherr:test .
