### PR TITLE
Add automated-agent Jellyfin playback probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Search results can always include synced Fetcherr library items. When Stremio se
 > [!NOTE]
 > The `/search` endpoint presents a separate Jellyfin server identity with no library folders or library items. Infuse can use that second connection for search results, while the normal connection remains available for Library Mode browsing and scanning.
 
+### Experimental Infuse version discovery
+
+This branch also preserves a separate Infuse workaround for version discovery. Some Infuse library views only request compact list items and do not request their detail records, so Fetcherr never gets the opportunity to resolve and expose the real Stremio-backed versions. When **Media source selection** is enabled, Fetcherr advertises two lightweight discovery markers on movie and episode list items; when Infuse follows up with the detail or playback request, those markers are replaced by the real filtered and renamed playable sources. Series folders remain non-playable, so discovery markers belong on their episode items rather than on the series itself. The markers are not separate transcodes or quality profiles, and the `A`/`B` names are discovery signals only. Library enumeration performs no provider probing; actual sources are resolved just in time when Infuse requests them. Provider responses are cached briefly and duplicate in-flight probes are coalesced. This is client-specific experimental behavior and should be evaluated independently before proposing it upstream.
+
 ## Connecting VidHub
 
 Add Fetcherr as a Jellyfin server in VidHub. If prompted for an Emby endpoint, use `http://YOUR_SERVER:9990/emby`.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ This branch also preserves a separate Infuse workaround for version discovery. S
 
 Add Fetcherr as a Jellyfin server in VidHub. If prompted for an Emby endpoint, use `http://YOUR_SERVER:9990/emby`.
 
+## Jellyfin playback probe
+
+`scripts/integration/jellyfin-playback-probe.mjs` is a client-side integration probe. It exercises a Jellyfin-compatible endpoint (Fetcherr by default, or a real Jellyfin server) through authentication, search, playback-info/media-source discovery, redirect handling, and a small provider byte request. It does not provide a mock Jellyfin server.
+
+Run it with `npm run probe:jellyfin`. Set `JELLYFIN_BASE_URL` to target another endpoint and use the `JELLYFIN_PROBE_*` variables shown by `npm run probe:jellyfin -- --help` to select media and playback checks.
+
 ## Environment
 
 | Variable | Description |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Add Fetcherr as a Jellyfin server in VidHub. If prompted for an Emby endpoint, u
 
 Run it with `npm run probe:jellyfin`. Set `JELLYFIN_BASE_URL` to target another endpoint and use the `JELLYFIN_PROBE_*` variables shown by `npm run probe:jellyfin -- --help` to select media and playback checks.
 
+To probe a specific episode, set the series, season, and episode explicitly:
+
+```bash
+JELLYFIN_PROBE_MEDIA=episode \
+JELLYFIN_PROBE_SERIES="Series name" \
+JELLYFIN_PROBE_SEASON=2 \
+JELLYFIN_PROBE_EPISODE=13 \
+npm run probe:jellyfin
+```
+
 ## Environment
 
 | Variable | Description |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && mkdir -p dist/ui/static && cp src/ui/*.html dist/ui/ && cp -R src/ui/static/. dist/ui/static/",
-    "mock:jellyfin": "node scripts/mock-jellyfin-client.mjs",
+    "probe:jellyfin": "node scripts/integration/jellyfin-playback-probe.mjs",
     "start": "node dist/index.js",
     "dev": "node --watch --import tsx/esm src/index.ts"
   },

--- a/scripts/integration/jellyfin-playback-probe.mjs
+++ b/scripts/integration/jellyfin-playback-probe.mjs
@@ -1,36 +1,37 @@
 #!/usr/bin/env node
 
-const baseUrl = (process.env.FETCHERR_URL || 'http://127.0.0.1:9990').replace(/\/$/, '')
-const mediaKind = (process.env.JELLYFIN_MOCK_MEDIA || 'movie').toLowerCase()
-const movieSearchTerm = process.env.JELLYFIN_MOCK_MOVIE || 'Killers of the Flower Moon'
-const seriesSearchTerm = process.env.JELLYFIN_MOCK_SERIES || 'Game of Thrones'
-const requestedSourceIndex = Number.parseInt(process.env.JELLYFIN_MOCK_SOURCE_INDEX || '0', 10)
-const rangeHeader = process.env.JELLYFIN_MOCK_RANGE || 'bytes=0-1023'
-const minMediaSources = Number.parseInt(process.env.JELLYFIN_MOCK_MIN_SOURCES || '1', 10)
-const maxMediaSources = Number.parseInt(process.env.JELLYFIN_MOCK_MAX_SOURCES || '10', 10)
+const baseUrl = (process.env.JELLYFIN_BASE_URL || 'http://127.0.0.1:9990').replace(/\/$/, '')
+const mediaKind = (process.env.JELLYFIN_PROBE_MEDIA || 'movie').toLowerCase()
+const movieSearchTerm = process.env.JELLYFIN_PROBE_MOVIE || 'Killers of the Flower Moon'
+const seriesSearchTerm = process.env.JELLYFIN_PROBE_SERIES || 'Game of Thrones'
+const requestedSourceIndex = Number.parseInt(process.env.JELLYFIN_PROBE_SOURCE_INDEX || '0', 10)
+const rangeHeader = process.env.JELLYFIN_PROBE_RANGE || 'bytes=0-1023'
+const minMediaSources = Number.parseInt(process.env.JELLYFIN_PROBE_MIN_SOURCES || '1', 10)
+const maxMediaSources = Number.parseInt(process.env.JELLYFIN_PROBE_MAX_SOURCES || '10', 10)
 
 if (process.argv.includes('--help') || process.argv.includes('-h')) {
-  console.log(`Usage: npm run mock:jellyfin
+  console.log(`Usage: npm run probe:jellyfin
 
 Environment:
-  FETCHERR_URL                  Fetcherr base URL, default http://127.0.0.1:9990
+  JELLYFIN_BASE_URL             Jellyfin-compatible base URL, default http://127.0.0.1:9990
   JELLYFIN_TOKEN                Existing Jellyfin access token
   JELLYFIN_USERNAME/PASSWORD    Credentials used when no token is supplied
-  JELLYFIN_MOCK_MEDIA           movie, episode, or all; default movie
-  JELLYFIN_MOCK_MOVIE           Movie search term; default Killers of the Flower Moon
-  JELLYFIN_MOCK_SERIES          Series search term; default Game of Thrones
-  JELLYFIN_MOCK_SOURCE_INDEX    MediaSource index to play; default 0
-  JELLYFIN_MOCK_MAX_SOURCES     Maximum expected MediaSources; default 10
+  JELLYFIN_PROBE_MEDIA          movie, episode, or all; default movie
+  JELLYFIN_PROBE_MOVIE          Movie search term; default Killers of the Flower Moon
+  JELLYFIN_PROBE_SERIES         Series search term; default Game of Thrones
+  JELLYFIN_PROBE_SOURCE_INDEX   MediaSource index to play; default 0
+  JELLYFIN_PROBE_MIN_SOURCES    Minimum expected MediaSources; default 1
+  JELLYFIN_PROBE_MAX_SOURCES    Maximum expected MediaSources; default 10
 `)
   process.exit(0)
 }
 
 if (!['movie', 'episode', 'all'].includes(mediaKind)) {
-  fail('JELLYFIN_MOCK_MEDIA must be movie, episode, or all')
+  fail('JELLYFIN_PROBE_MEDIA must be movie, episode, or all')
 }
 
 function fail(message) {
-  console.error(`mock-jellyfin: ${message}`)
+  console.error(`jellyfin-playback-probe: ${message}`)
   process.exit(1)
 }
 
@@ -57,7 +58,7 @@ async function authenticate() {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
-      'x-emby-authorization': 'MediaBrowser Client="Fetcherr Mock", Device="CLI", DeviceId="fetcherr-mock", Version="1.0"',
+      'x-emby-authorization': 'MediaBrowser Client="Jellyfin Playback Probe", Device="CLI", DeviceId="jellyfin-playback-probe", Version="1.0"',
     },
     body: JSON.stringify({ Username: username, Pw: password }),
   })
@@ -70,9 +71,9 @@ async function jellyfin(token, path) {
   return request(path, {
     headers: {
       'x-emby-token': token,
-      'x-emby-client': 'Fetcherr Mock',
+      'x-emby-client': 'Jellyfin Playback Probe',
       'x-emby-device-name': 'CLI',
-      'x-emby-device-id': 'fetcherr-mock',
+      'x-emby-device-id': 'jellyfin-playback-probe',
     },
   })
 }

--- a/scripts/integration/jellyfin-playback-probe.mjs
+++ b/scripts/integration/jellyfin-playback-probe.mjs
@@ -4,6 +4,8 @@ const baseUrl = (process.env.JELLYFIN_BASE_URL || 'http://127.0.0.1:9990').repla
 const mediaKind = (process.env.JELLYFIN_PROBE_MEDIA || 'movie').toLowerCase()
 const movieSearchTerm = process.env.JELLYFIN_PROBE_MOVIE || 'Killers of the Flower Moon'
 const seriesSearchTerm = process.env.JELLYFIN_PROBE_SERIES || 'Game of Thrones'
+const requestedSeason = parsePositiveInteger(process.env.JELLYFIN_PROBE_SEASON || '1', 'JELLYFIN_PROBE_SEASON')
+const requestedEpisode = parsePositiveInteger(process.env.JELLYFIN_PROBE_EPISODE || '1', 'JELLYFIN_PROBE_EPISODE')
 const requestedSourceIndex = Number.parseInt(process.env.JELLYFIN_PROBE_SOURCE_INDEX || '0', 10)
 const rangeHeader = process.env.JELLYFIN_PROBE_RANGE || 'bytes=0-1023'
 const minMediaSources = Number.parseInt(process.env.JELLYFIN_PROBE_MIN_SOURCES || '1', 10)
@@ -19,6 +21,8 @@ Environment:
   JELLYFIN_PROBE_MEDIA          movie, episode, or all; default movie
   JELLYFIN_PROBE_MOVIE          Movie search term; default Killers of the Flower Moon
   JELLYFIN_PROBE_SERIES         Series search term; default Game of Thrones
+  JELLYFIN_PROBE_SEASON         Season number; default 1
+  JELLYFIN_PROBE_EPISODE        Episode number within the season; default 1
   JELLYFIN_PROBE_SOURCE_INDEX   MediaSource index to play; default 0
   JELLYFIN_PROBE_MIN_SOURCES    Minimum expected MediaSources; default 1
   JELLYFIN_PROBE_MAX_SOURCES    Maximum expected MediaSources; default 10
@@ -33,6 +37,12 @@ if (!['movie', 'episode', 'all'].includes(mediaKind)) {
 function fail(message) {
   console.error(`jellyfin-playback-probe: ${message}`)
   process.exit(1)
+}
+
+function parsePositiveInteger(value, name) {
+  const number = Number.parseInt(value, 10)
+  if (!Number.isInteger(number) || number < 1) fail(`${name} must be a positive integer`)
+  return number
 }
 
 async function request(path, options = {}) {
@@ -123,15 +133,15 @@ async function selectEpisode(token, userId) {
     token,
     `/Users/${encodeURIComponent(userId)}/Items?ParentId=${encodeURIComponent(series.Id)}&IncludeItemTypes=Season&Limit=100`,
   )
-  const season = seasons.Items?.find(candidate => candidate.IndexNumber === 1) ?? seasons.Items?.[0]
-  if (!season) fail(`series "${series.Name}" returned no seasons`)
+  const season = seasons.Items?.find(candidate => candidate.IndexNumber === requestedSeason)
+  if (!season) fail(`series "${series.Name}" returned no season ${requestedSeason}`)
 
   const episodes = await jellyfin(
     token,
     `/Users/${encodeURIComponent(userId)}/Items?ParentId=${encodeURIComponent(season.Id)}&IncludeItemTypes=Episode&Limit=100`,
   )
-  const episode = episodes.Items?.find(candidate => candidate.ParentIndexNumber === 1 && candidate.IndexNumber === 1) ?? episodes.Items?.[0]
-  if (!episode) fail(`season "${season.Name}" returned no episodes`)
+  const episode = episodes.Items?.find(candidate => candidate.ParentIndexNumber === requestedSeason && candidate.IndexNumber === requestedEpisode)
+  if (!episode) fail(`season "${season.Name}" returned no episode ${requestedEpisode}`)
   return episode
 }
 

--- a/scripts/mock-jellyfin-client.mjs
+++ b/scripts/mock-jellyfin-client.mjs
@@ -6,7 +6,7 @@ const movieSearchTerm = process.env.JELLYFIN_MOCK_MOVIE || 'Killers of the Flowe
 const seriesSearchTerm = process.env.JELLYFIN_MOCK_SERIES || 'Game of Thrones'
 const requestedSourceIndex = Number.parseInt(process.env.JELLYFIN_MOCK_SOURCE_INDEX || '0', 10)
 const rangeHeader = process.env.JELLYFIN_MOCK_RANGE || 'bytes=0-1023'
-const minMediaSources = Number.parseInt(process.env.JELLYFIN_MOCK_MIN_SOURCES || '2', 10)
+const minMediaSources = Number.parseInt(process.env.JELLYFIN_MOCK_MIN_SOURCES || '1', 10)
 const maxMediaSources = Number.parseInt(process.env.JELLYFIN_MOCK_MAX_SOURCES || '10', 10)
 
 if (process.argv.includes('--help') || process.argv.includes('-h')) {
@@ -147,12 +147,12 @@ async function verifyPlayback(token, item, label) {
     redirect: 'manual',
     headers: { range: rangeHeader },
   })
-  if (redirect.status !== 302) {
+  if (redirect.status < 300 || redirect.status >= 400) {
     const text = await redirect.text()
     fail(`${label} source "${source.Name}" did not redirect to provider; status=${redirect.status} body=${text.slice(0, 300)}`)
   }
   const location = redirect.headers.get('location')
-  if (!location) fail(`${label} source "${source.Name}" returned 302 without Location`)
+  if (!location) fail(`${label} source "${source.Name}" returned ${redirect.status} without Location`)
 
   const media = await fetch(location, {
     redirect: 'follow',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1759,9 +1759,18 @@ async function resolveStremioPlayback(mediaType: StremioMediaType, externalId: s
   return resolvePlayableStream(streams, `${mediaType} ${externalId}`, playPath, undefined, true)
 }
 
-async function resolveEpisodePlayback(imdbId: string, season: number, episodeNumber: number, playbackClient = ''): Promise<PlayResolution> {
+async function resolveEpisodePlayback(
+  imdbId: string,
+  season: number,
+  episodeNumber: number,
+  playbackClient = '',
+  profileKey?: PlaybackProfileKey,
+): Promise<PlayResolution> {
   const playPath = `/play/${imdbId}/${season}/${episodeNumber}`
-  const label = `${imdbId} S${season}E${episodeNumber}`
+  const profile = playbackProfileForKey(profileKey)
+  const baseLabel = `${imdbId} S${season}E${episodeNumber}`
+  const label = profile ? `${baseLabel} (${profile.name})` : baseLabel
+  const resolutionKey = profile ? `${playPath}:profile:${profile.key}` : playPath
   const show = getShowByImdbId(imdbId)
   const episode = show
     ? getEpisodesForSeason(show.tmdbId, season).find(ep => ep.episodeNumber === episodeNumber)
@@ -1776,6 +1785,7 @@ async function resolveEpisodePlayback(imdbId: string, season: number, episodeNum
 
   const hasStreamProvider = Boolean(config.sootioUrl) || config.streamProviderUrls.length > 0
   const hasUsenet = isUsenetConfigured()
+  const runtimeTicks = (episode?.runtimeMins || 45) * 60 * 10_000_000
 
   if (hasStreamProvider) {
     try {
@@ -1791,10 +1801,14 @@ async function resolveEpisodePlayback(imdbId: string, season: number, episodeNum
         playbackClient,
         config.streamRankingMode === 'provider',
       )
+      const orderedStreams = streamsForPlaybackProfile(streams, profileKey, runtimeTicks)
+      if (profile) {
+        app.log.info(`play: profile ${profile.name} selected for ${label}, trying closest of ${orderedStreams.length} streams`)
+      }
       return await resolvePlayableStream(
-        streams,
+        orderedStreams,
         label,
-        playPath,
+        resolutionKey,
         `s${pad2(season)}e${pad2(episodeNumber)}`,
         true,
       )
@@ -1807,7 +1821,7 @@ async function resolveEpisodePlayback(imdbId: string, season: number, episodeNum
   if (hasUsenet) {
     const { url, filename } = await resolveUsenetEpisodeStream(imdbId, season, episodeNumber)
     app.log.info(`play: usenet resolved ${filename} for ${label}`)
-    clearFailedPlay(playPath)
+    clearFailedPlay(resolutionKey)
     return { url, filename, provider: 'Usenet' }
   }
 
@@ -1918,8 +1932,10 @@ app.get('/play/:imdbId', async (req, reply) => {
 
 app.get('/play/:imdbId/:season/:episode', async (req, reply) => {
   const { imdbId, season, episode } = req.params as { imdbId: string; season: string; episode: string }
-  const query = req.query as { token?: string; expires?: string; candidate?: string } | undefined
+  const query = req.query as { token?: string; expires?: string; candidate?: string; profile?: string } | undefined
   const playPath = `/play/${imdbId}/${season}/${episode}`
+  const profile = playbackProfileForKey(query?.profile)
+  const resolutionKey = profile ? `${playPath}:profile:${profile.key}` : playPath
   if (!verifySignedPlaybackPath(playPath, query?.token, query?.expires)) {
     if (!requestPlaybackUser(req.headers)) {
       app.log.warn(`play: rejected unauthenticated episode playback request for ${imdbId} S${season}E${episode}`)
@@ -1928,31 +1944,33 @@ app.get('/play/:imdbId/:season/:episode', async (req, reply) => {
     }
     return reply.code(401).send({ error: 'Unauthorized' })
   }
-  const failedReason = getFailedPlayReason(playPath)
+  const failedReason = getFailedPlayReason(resolutionKey)
   if (failedReason) {
-    app.log.info(`play: cached miss for ${imdbId} S${season}E${episode} (${failedReason})`)
+    const baseLabel = `${imdbId} S${season}E${episode}`
+    const label = profile ? `${baseLabel} (${profile.name})` : baseLabel
+    app.log.info(`play: cached miss for ${label} (${failedReason})`)
     return reply.code(404).send({ error: failedReason, message: 'No Streams Found' })
   }
   const s = parseInt(season)
   const e = parseInt(episode)
-  app.log.info(`play: resolving episode stream for ${imdbId} S${s}E${e}`)
+  const label = profile ? `${imdbId} S${s}E${e} (${profile.name})` : `${imdbId} S${s}E${e}`
+  app.log.info(`play: resolving episode stream for ${label}`)
   try {
-    const label = `${imdbId} S${s}E${e}`
     const clientName = playbackClientName(playPath)
     const selectedCandidate = await resolvePlaybackCandidate(query?.candidate, playPath)
     const resolved = selectedCandidate ?? await (async () => {
-      const { promise, reused } = getOrCreatePlaybackResolution(playPath, label, () => resolveEpisodePlayback(imdbId, s, e, clientName))
+      const { promise, reused } = getOrCreatePlaybackResolution(resolutionKey, label, () => resolveEpisodePlayback(imdbId, s, e, clientName, profile?.key))
       if (reused) app.log.info(`play: using in-flight resolver for ${label}`)
       return promise
     })()
-    rememberTorBoxPlaybackUrl(playPath, resolved)
+    rememberTorBoxPlaybackUrl(resolutionKey, resolved)
     return reply.redirect(resolved.url, 302)
   } catch (err) {
     if (err instanceof PlaybackResolutionError) {
       return reply.code(err.statusCode).send(err.response)
     }
-    app.log.warn(`play: no stream for ${imdbId} S${s}E${e}: ${err}`)
-    cacheFailedPlay(playPath, 'No streams found')
+    app.log.warn(`play: no stream for ${label}: ${err}`)
+    cacheFailedPlay(resolutionKey, 'No streams found')
     return reply.code(404).send({ error: 'No stream available', message: 'No Streams Found' })
   }
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { getShowByImdbId, getMovieByImdbId, getEpisodesForSeason, getLatestSeaso
 import { ensureShowSeasonsCached, refreshShowMetadataIfNeeded, refreshMovieMetadataIfNeeded } from './tmdb.js'
 import { getSessionUser, getTokenFromCookie, isUiAuthConfigured, isValidSession } from './ui/auth.js'
 import { createSignedPlaybackUrl, verifySignedPlaybackPath } from './play-auth.js'
+import { playbackProfileForKey, type PlaybackProfileKey } from './playback-profiles.js'
 import { isUsenetConfigured, resolveUsenetMovieStream, resolveUsenetEpisodeStream, usenetStreamJobs } from './usenet/resolve.js'
 import { getNntpPool } from './usenet/nntp-pool.js'
 import { ydecode } from './usenet/ydecode.js'
@@ -1449,6 +1450,13 @@ function streamVideoDimensions(stream: Stream): { width: number; height: number 
   return { width: 1920, height: 1080 }
 }
 
+function streamVideoHeight(stream: Stream): number | undefined {
+  const text = streamMetadataText(stream)
+  if (/\b(2160p|4k|uhd)\b/i.test(text)) return 2160
+  const match = text.match(/\b(1440|1080|720|576|480|360)p\b/i)
+  return match ? Number.parseInt(match[1], 10) : undefined
+}
+
 function streamBitrate(sizeBytes: number | undefined, runtimeTicks: number): number | undefined {
   if (!sizeBytes || runtimeTicks <= 0) return undefined
   const seconds = runtimeTicks / 10_000_000
@@ -1477,6 +1485,36 @@ function detectStreamAudioLanguage(stream?: Stream): string {
   const parsed = parseStreamMetadata(stream, text)
   const code = (parsed.languages ?? []).find(lang => lang in LANGUAGE_ISO3)
   return code ? LANGUAGE_ISO3[code] : 'eng'
+}
+
+function streamsForPlaybackProfile(
+  streams: Stream[],
+  profileKey: PlaybackProfileKey | undefined,
+  runtimeTicks: number,
+): Stream[] {
+  const profile = playbackProfileForKey(profileKey)
+  if (!profile || (!profile.targetHeight && !profile.targetBitrateMbps)) return streams
+
+  return streams
+    .map((stream, index) => {
+      const height = streamVideoHeight(stream)
+      const bitrate = streamBitrate(streamSizeBytes(stream), runtimeTicks)
+      const heightDistance = profile.targetHeight
+        ? (height == null ? 1.5 : Math.abs(height - profile.targetHeight) / profile.targetHeight)
+        : 0
+      const bitrateDistance = profile.targetBitrateMbps
+        ? (bitrate == null
+          ? 1.5
+          : Math.abs(bitrate - profile.targetBitrateMbps * 1_000_000) / (profile.targetBitrateMbps * 1_000_000))
+        : 0
+      return {
+        stream,
+        index,
+        score: heightDistance * 250 + bitrateDistance * 25,
+      }
+    })
+    .sort((a, b) => a.score - b.score || a.index - b.index)
+    .map(entry => entry.stream)
 }
 
 function playbackMediaSource(id: string, name: string, path: string, runtimeTicks: number, stream?: Stream) {
@@ -1587,6 +1625,11 @@ async function buildPlaybackMediaSources(input: {
     const qualityRanked = streams.filter(stream => (stream.url || extractHashFromStream(stream)) && streamEligibleForMediaSourceSelection(stream))
     const usable = qualityRanked.slice(0, config.mediaSourceLimit)
 
+    app.log.info(
+      `playback: versions for ${input.name}: ${streams.length} ranked, ${qualityRanked.length} eligible, offering ${usable.length}` +
+      (usable.length ? ` [${usable.map((stream, index) => streamOptionName(stream, input.name, index)).join(' | ')}]` : ''),
+    )
+
     if (!usable.length) return [fallbackSource]
 
     return usable.map((stream, index) => {
@@ -1668,24 +1711,37 @@ app.get('/usenet/stream/:jobId', async (req, reply) => {
     reply.raw.end()
   }
 })
-async function resolveMoviePlayback(imdbId: string, playbackClient = ''): Promise<PlayResolution> {
+async function resolveMoviePlayback(
+  imdbId: string,
+  playbackClient = '',
+  profileKey?: PlaybackProfileKey,
+): Promise<PlayResolution> {
   const playPath = `/play/${imdbId}`
   const hasStreamProvider = Boolean(config.sootioUrl) || config.streamProviderUrls.length > 0
   const hasUsenet = isUsenetConfigured()
+  const movie = profileKey ? getMovieByImdbId(imdbId) : null
+  const runtimeTicks = (movie?.runtimeMins || 90) * 60 * 10_000_000
+  const profile = playbackProfileForKey(profileKey)
+  const label = profile ? `${imdbId} (${profile.name})` : imdbId
 
   if (hasStreamProvider) {
     try {
       const streams = await fetchRankedStreams(imdbId, config.preferredAudioLanguage, '', playbackClient, config.streamRankingMode === 'provider')
-      return await resolvePlayableStream(streams, imdbId, playPath, undefined, true)
+      const orderedStreams = streamsForPlaybackProfile(streams, profileKey, runtimeTicks)
+      if (profile) {
+        app.log.info(`play: profile ${profile.name} selected for ${imdbId}, trying closest of ${orderedStreams.length} streams`)
+      }
+      const resolutionKey = profile ? `${playPath}:profile:${profile.key}` : playPath
+      return await resolvePlayableStream(orderedStreams, label, resolutionKey, undefined, true)
     } catch (err) {
       if (!hasUsenet) throw err
-      app.log.info(`play: stream provider failed for ${imdbId}, falling back: ${err}`)
+      app.log.info(`play: stream provider failed for ${label}, falling back: ${err}`)
     }
   }
 
   if (hasUsenet) {
     const { url, filename } = await resolveUsenetMovieStream(imdbId)
-    app.log.info(`play: usenet resolved ${filename} for ${imdbId}`)
+    app.log.info(`play: usenet resolved ${filename} for ${label}`)
     clearFailedPlay(playPath)
     return { url, filename, provider: 'Usenet' }
   }
@@ -1821,8 +1877,10 @@ app.get('/play/stremio/:mediaType/:externalId', async (req, reply) => {
 
 app.get('/play/:imdbId', async (req, reply) => {
   const { imdbId } = req.params as { imdbId: string }
-  const query = req.query as { token?: string; expires?: string; candidate?: string } | undefined
+  const query = req.query as { token?: string; expires?: string; candidate?: string; profile?: string } | undefined
   const playPath = `/play/${imdbId}`
+  const profile = playbackProfileForKey(query?.profile)
+  const resolutionKey = profile ? `${playPath}:profile:${profile.key}` : playPath
   if (!verifySignedPlaybackPath(playPath, query?.token, query?.expires)) {
     if (!requestPlaybackUser(req.headers)) {
       app.log.warn(`play: rejected unauthenticated playback request for ${imdbId}`)
@@ -1831,28 +1889,29 @@ app.get('/play/:imdbId', async (req, reply) => {
     }
     return reply.code(401).send({ error: 'Unauthorized' })
   }
-  const failedReason = getFailedPlayReason(playPath)
+  const failedReason = getFailedPlayReason(resolutionKey)
   if (failedReason) {
-    app.log.info(`play: cached miss for ${imdbId} (${failedReason})`)
+    app.log.info(`play: cached miss for ${profile ? `${imdbId} (${profile.name})` : imdbId} (${failedReason})`)
     return reply.code(404).send({ error: failedReason, message: 'No Streams Found' })
   }
-  app.log.info(`play: resolving stream for ${imdbId}`)
+  app.log.info(`play: resolving stream for ${profile ? `${imdbId} (${profile.name})` : imdbId}`)
   try {
     const clientName = playbackClientName(playPath)
     const selectedCandidate = await resolvePlaybackCandidate(query?.candidate, playPath)
     const resolved = selectedCandidate ?? await (async () => {
-      const { promise, reused } = getOrCreatePlaybackResolution(playPath, imdbId, () => resolveMoviePlayback(imdbId, clientName))
-      if (reused) app.log.info(`play: using in-flight resolver for ${imdbId}`)
+      const label = profile ? `${imdbId} (${profile.name})` : imdbId
+      const { promise, reused } = getOrCreatePlaybackResolution(resolutionKey, label, () => resolveMoviePlayback(imdbId, clientName, profile?.key))
+      if (reused) app.log.info(`play: using in-flight resolver for ${label}`)
       return promise
     })()
-    rememberTorBoxPlaybackUrl(playPath, resolved)
+    rememberTorBoxPlaybackUrl(resolutionKey, resolved)
     return reply.redirect(resolved.url, 302)
   } catch (err) {
     if (err instanceof PlaybackResolutionError) {
       return reply.code(err.statusCode).send(err.response)
     }
-    app.log.warn(`play: no stream for ${imdbId}: ${err}`)
-    cacheFailedPlay(playPath, 'No streams found')
+    app.log.warn(`play: no stream for ${profile ? `${imdbId} (${profile.name})` : imdbId}: ${err}`)
+    cacheFailedPlay(resolutionKey, 'No streams found')
     return reply.code(404).send({ error: 'No stream available', message: 'No Streams Found' })
   }
 })

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -49,7 +49,7 @@ const SHOWS_FOLDER_ID  = 'a0000000-0000-4000-8000-000000000002'
 const COLLECTIONS_FOLDER_ID = 'a0000000-0000-4000-8007-000000000001'
 const SEARCH_DISABLED_ITEM_ID = 'a0000000-0000-4000-800a-000000000001'
 const SEARCH_DISABLED_RUNTIME_TICKS = 60 * 10_000_000
-const MEDIA_SOURCE_ITEM_ETAG_VERSION = 'media-sources-discovery-v3'
+const MEDIA_SOURCE_ITEM_ETAG_VERSION = 'media-sources-discovery-v4'
 const SERVER_GUID      = 'a0000000-0000-0000-0000-000000000001'
 const SEARCH_SERVER_GUID = 'a0000000-0000-0000-0000-00000000f001'
 const DISCOVER_FOLDER_ID = 'a0000000-0000-4000-8000-000000000003'
@@ -1296,14 +1296,23 @@ function userDataForItem(itemId: string, ud: { played: boolean; playCount: numbe
   }
 }
 
-function movieItemEtag(movie: Movie): string {
+function mediaSourceItemEtag(scope: string, identity: string | number, syncedAt: string | undefined): string {
   return createHash('md5').update([
     MEDIA_SOURCE_ITEM_ETAG_VERSION,
-    movie.tmdbId,
-    movie.syncedAt,
+    scope,
+    identity,
+    syncedAt,
     config.mediaSourceSelection ? 'versions-enabled' : 'versions-disabled',
     config.mediaSourceLimit,
   ].join(':')).digest('hex')
+}
+
+function movieItemEtag(movie: Movie): string {
+  return mediaSourceItemEtag('movie', movie.tmdbId, movie.syncedAt)
+}
+
+function episodeItemEtag(ep: Episode, show: Show): string {
+  return mediaSourceItemEtag('episode', `${show.tmdbId}:${ep.seasonNumber}:${ep.episodeNumber}`, ep.syncedAt)
 }
 
 function virtualProfileMediaSourceId(itemId: string, profile: PlaybackProfile): string {
@@ -1328,8 +1337,8 @@ function virtualProfileDimensions(profile: PlaybackProfile): { width: number; he
   }
 }
 
-function virtualProfileMediaSources(movie: Movie, itemId: string, runtimeTicks: number) {
-  if (!config.mediaSourceSelection || !movie.imdbId) return []
+function virtualProfileMediaSources(itemId: string, runtimeTicks: number, hasPlaybackIdentity: boolean) {
+  if (!config.mediaSourceSelection || !hasPlaybackIdentity) return []
   if (!config.sootioUrl && config.streamProviderUrls.length === 0) return []
 
   return PLAYBACK_PROFILES.map(profile => {
@@ -1379,7 +1388,7 @@ function movieToItem(m: Movie, userId = DEFAULT_ADMIN_USER_ID) {
   const posterTag = m.posterPath ? m.posterPath.replace(/\W/g, '').slice(0, 16) : undefined
   const thumbTag = (m.backdropPath || m.posterPath) ? (m.backdropPath || m.posterPath).replace(/\W/g, '').slice(0, 16) : undefined
   const logoTag = m.logoPath ? m.logoPath.replace(/\W/g, '').slice(0, 16) : undefined
-  const virtualMediaSources = virtualProfileMediaSources(m, id, runtimeTicks)
+  const virtualMediaSources = virtualProfileMediaSources(id, runtimeTicks, Boolean(m.imdbId))
   return {
     Id:                 id,
     ServerId:           SERVER_GUID,
@@ -2268,6 +2277,7 @@ function episodeToItem(ep: Episode, show: Show, userId = DEFAULT_ADMIN_USER_ID) 
   const showPosterTag = show.posterPath ? show.posterPath.replace(/\W/g, '').slice(0, 16) : undefined
   const showBackdropTag = show.backdropPath ? show.backdropPath.replace(/\W/g, '').slice(0, 16) : undefined
   const showLogoTag = show.logoPath ? show.logoPath.replace(/\W/g, '').slice(0, 16) : undefined
+  const virtualMediaSources = virtualProfileMediaSources(id, runtimeTicks, Boolean(show.imdbId))
   return {
     Id:                    id,
     ServerId:              SERVER_GUID,
@@ -2295,11 +2305,18 @@ function episodeToItem(ep: Episode, show: Show, userId = DEFAULT_ADMIN_USER_ID) 
     ExternalUrls:          null,
     PremiereDate:          jellyfinPremiereDate(ep.airDate),
     DateCreated:           ep.airDate ? `${ep.airDate}T00:00:00Z` : ep.syncedAt,
+    Etag:                  episodeItemEtag(ep, show),
     IsFolder:              false,
     IndexNumber:           ep.episodeNumber,
     ParentIndexNumber:     ep.seasonNumber,
     RunTimeTicks:          runtimeTicks,
     Path:                  fakePath,
+    EnableMediaSourceDisplay: true,
+    ...(virtualMediaSources.length ? {
+      MediaSources: virtualMediaSources,
+      AlternateMediaSources: virtualMediaSources,
+      MediaSourceCount: virtualMediaSources.length,
+    } : {}),
     ImageTags:             ep.stillPath ? { Primary: 'still' } : (showBackdropTag ? { Primary: showBackdropTag } : {}),
     PrimaryImageTag:       undefined,
     BackdropImageTags:     [],

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -25,6 +25,7 @@ import { buildPlaybackOrigin, createSignedPlaybackUrl } from '../play-auth.js'
 import { mdblistListPathFromUrl } from '../mdblist.js'
 import { fetchStremioMeta, searchStremioMetas, type StremioMediaType, type StremioMeta } from '../sootio.js'
 import { searchTraktMetas } from '../trakt.js'
+import { PLAYBACK_PROFILES, playbackProfileForKey, type PlaybackProfile } from '../playback-profiles.js'
 
 // ── ID helpers ────────────────────────────────────────────────────────────────
 // Real Jellyfin uses GUIDs for all IDs. Infuse validates this client-side.
@@ -48,6 +49,7 @@ const SHOWS_FOLDER_ID  = 'a0000000-0000-4000-8000-000000000002'
 const COLLECTIONS_FOLDER_ID = 'a0000000-0000-4000-8007-000000000001'
 const SEARCH_DISABLED_ITEM_ID = 'a0000000-0000-4000-800a-000000000001'
 const SEARCH_DISABLED_RUNTIME_TICKS = 60 * 10_000_000
+const MEDIA_SOURCE_ITEM_ETAG_VERSION = 'media-sources-discovery-v3'
 const SERVER_GUID      = 'a0000000-0000-0000-0000-000000000001'
 const SEARCH_SERVER_GUID = 'a0000000-0000-0000-0000-00000000f001'
 const DISCOVER_FOLDER_ID = 'a0000000-0000-4000-8000-000000000003'
@@ -1294,6 +1296,80 @@ function userDataForItem(itemId: string, ud: { played: boolean; playCount: numbe
   }
 }
 
+function movieItemEtag(movie: Movie): string {
+  return createHash('md5').update([
+    MEDIA_SOURCE_ITEM_ETAG_VERSION,
+    movie.tmdbId,
+    movie.syncedAt,
+    config.mediaSourceSelection ? 'versions-enabled' : 'versions-disabled',
+    config.mediaSourceLimit,
+  ].join(':')).digest('hex')
+}
+
+function virtualProfileMediaSourceId(itemId: string, profile: PlaybackProfile): string {
+  return `${itemId}:profile:${profile.key}`
+}
+
+function virtualProfilePath(itemId: string, mediaSourceId: string): string {
+  const params = new URLSearchParams({
+    PlaySessionId: `fetcherr-${itemId}`,
+    MediaSourceId: mediaSourceId,
+  })
+  return `/Videos/${encodeURIComponent(itemId)}/stream?${params.toString()}`
+}
+
+function virtualProfileDimensions(profile: PlaybackProfile): { width: number; height: number } {
+  switch (profile.targetHeight) {
+    case 2160: return { width: 3840, height: 2160 }
+    case 1080: return { width: 1920, height: 1080 }
+    case 720: return { width: 1280, height: 720 }
+    case 360: return { width: 640, height: 360 }
+    default: return { width: 1920, height: 1080 }
+  }
+}
+
+function virtualProfileMediaSources(movie: Movie, itemId: string, runtimeTicks: number) {
+  if (!config.mediaSourceSelection || !movie.imdbId) return []
+  if (!config.sootioUrl && config.streamProviderUrls.length === 0) return []
+
+  return PLAYBACK_PROFILES.map(profile => {
+    const mediaSourceId = virtualProfileMediaSourceId(itemId, profile)
+    const { width, height } = virtualProfileDimensions(profile)
+    const bitrate = profile.targetBitrateMbps
+      ? profile.targetBitrateMbps * 1_000_000
+      : undefined
+    return {
+      Id: mediaSourceId,
+      Name: profile.name,
+      Type: 'Default',
+      Protocol: 'Http',
+      Path: virtualProfilePath(itemId, mediaSourceId),
+      IsRemote: true,
+      SupportsDirectPlay: true,
+      SupportsDirectStream: true,
+      SupportsTranscoding: false,
+      RequiresOpening: false,
+      RequiresClosing: false,
+      Container: 'mkv',
+      Bitrate: bitrate,
+      VideoType: 'VideoFile',
+      RunTimeTicks: runtimeTicks,
+      DefaultAudioStreamIndex: 1,
+      MediaStreams: [
+        {
+          Type: 'Video',
+          Index: 0,
+          Codec: 'h264',
+          IsDefault: true,
+          Width: width,
+          Height: height,
+          BitRate: bitrate,
+        },
+        { Type: 'Audio', Index: 1, Codec: 'aac', IsDefault: true, Language: 'eng' },
+      ],
+    }
+  })
+}
 function movieToItem(m: Movie, userId = DEFAULT_ADMIN_USER_ID) {
   const genres: string[] = JSON.parse(m.genres || '[]')
   const runtimeTicks = (m.runtimeMins || 90) * 60 * 10_000_000
@@ -1303,6 +1379,7 @@ function movieToItem(m: Movie, userId = DEFAULT_ADMIN_USER_ID) {
   const posterTag = m.posterPath ? m.posterPath.replace(/\W/g, '').slice(0, 16) : undefined
   const thumbTag = (m.backdropPath || m.posterPath) ? (m.backdropPath || m.posterPath).replace(/\W/g, '').slice(0, 16) : undefined
   const logoTag = m.logoPath ? m.logoPath.replace(/\W/g, '').slice(0, 16) : undefined
+  const virtualMediaSources = virtualProfileMediaSources(m, id, runtimeTicks)
   return {
     Id:                 id,
     ServerId:           SERVER_GUID,
@@ -1328,10 +1405,16 @@ function movieToItem(m: Movie, userId = DEFAULT_ADMIN_USER_ID) {
     ExternalUrls:       externalUrls('movie', m.imdbId, m.tmdbId),
     PremiereDate:       jellyfinPremiereDate(m.releaseDate || m.digitalReleaseDate),
     DateCreated:        m.syncedAt,
+    Etag:               movieItemEtag(m),
     RunTimeTicks:       runtimeTicks,
     IsFolder:           false,
     Path:               fakePath,
     EnableMediaSourceDisplay: true,
+    ...(virtualMediaSources.length ? {
+      MediaSources: virtualMediaSources,
+      AlternateMediaSources: virtualMediaSources,
+      MediaSourceCount: virtualMediaSources.length,
+    } : {}),
     ImageTags:          {
       ...(posterTag ? { Primary: posterTag } : {}),
       ...(logoTag ? { Logo: logoTag } : {}),
@@ -1687,6 +1770,7 @@ function movieToSearchItem(m: Movie) {
     ExternalUrls:       externalUrls('movie', m.imdbId, m.tmdbId),
     PremiereDate:       jellyfinPremiereDate(m.releaseDate || m.digitalReleaseDate),
     DateCreated:        m.syncedAt,
+    Etag:               movieItemEtag(m),
     IsFolder:           false,
     ImageTags:          {
       ...(posterTag ? { Primary: posterTag } : {}),
@@ -2400,10 +2484,19 @@ function candidateTokenFromMediaSourceId(mediaSourceId: string | undefined): str
   return match?.[1] ?? null
 }
 
+function playbackProfileFromMediaSourceId(mediaSourceId: string | undefined, itemId?: string): PlaybackProfile | null {
+  if (!mediaSourceId) return null
+  if (itemId && !mediaSourceId.startsWith(`${itemId}:profile:`)) return null
+  const match = mediaSourceId.match(/:profile:([^:]+)$/i)
+  return playbackProfileForKey(match?.[1])
+}
+
 function signedPlaybackUrlForMediaSource(origin: string, playPath: string, mediaSourceId: string | undefined): string {
   const url = new URL(createSignedPlaybackUrl(origin, playPath))
   const candidate = candidateTokenFromMediaSourceId(mediaSourceId)
   if (candidate) url.searchParams.set('candidate', candidate)
+  const profile = playbackProfileFromMediaSourceId(mediaSourceId)
+  if (profile) url.searchParams.set('profile', profile.key)
   return url.toString()
 }
 
@@ -3337,11 +3430,13 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
   }
 
   app.get('/Items/:id', async (req, reply) => {
+    reply.header('Cache-Control', 'no-store')
     const user = requireRequestUser(req.headers, reply as never)
     if (!user) return
     return handleItem((req.params as { id: string }).id, reply as never, user, req.headers)
   })
   app.get('/Users/:userId/Items/:itemId', async (req, reply) => {
+    reply.header('Cache-Control', 'no-store')
     const user = requireRequestUser(req.headers, reply as never)
     if (!user) return
     return handleItem((req.params as { itemId: string }).itemId, reply as never, user, req.headers)
@@ -3929,8 +4024,14 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
     }
   }
 
-  app.get('/Items/:id/PlaybackInfo',  async (req, reply) => handlePlaybackInfo(req as never, reply as never))
-  app.post('/Items/:id/PlaybackInfo', async (req, reply) => handlePlaybackInfo(req as never, reply as never))
+  app.get('/Items/:id/PlaybackInfo',  async (req, reply) => {
+    reply.header('Cache-Control', 'no-store')
+    return handlePlaybackInfo(req as never, reply as never)
+  })
+  app.post('/Items/:id/PlaybackInfo', async (req, reply) => {
+    reply.header('Cache-Control', 'no-store')
+    return handlePlaybackInfo(req as never, reply as never)
+  })
 
   // Video stream redirect (fallback for some Infuse/VidHub versions)
   app.get('/Videos/:id/stream', async (req, reply) => {
@@ -3945,10 +4046,11 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       && mediaSourceId?.startsWith(`${id}:candidate:`)
       && opts.validatePlaybackCandidate?.(candidate, id),
     )
+    const profileMatches = Boolean(playbackProfileFromMediaSourceId(mediaSourceId, id))
     const headersWithToken = query?.api_key
       ? { ...req.headers as Record<string, string | string[] | undefined>, 'x-emby-token': query.api_key }
       : req.headers as Record<string, string | string[] | undefined>
-    const user = requestUser(headersWithToken) ?? ((sessionMatches || sourceMatches || candidateMatches) ? fallbackUser() : null)
+    const user = requestUser(headersWithToken) ?? ((sessionMatches || sourceMatches || candidateMatches || profileMatches) ? fallbackUser() : null)
 
     if (!user) return reply.code(401).send({ error: 'Unauthorized' })
 

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -935,7 +935,10 @@ function dateCreatedForSourcePosition(syncedAt: string | undefined, sourcePositi
   if (!sourcePosition || sourcePosition <= 0) return syncedAt
   const baseMs = Date.parse(syncedAt ?? '')
   if (!Number.isFinite(baseMs)) return syncedAt
-  return new Date(baseMs - ((sourcePosition - 1) * 1000)).toISOString()
+  // Treat the source ranking as an ordered sequence: rank 1 is the oldest
+  // synthetic date, so Infuse's normal ascending Date Added order shows the
+  // list's ranking order and descending reverses it.
+  return new Date(baseMs + ((sourcePosition - 1) * 1000)).toISOString()
 }
 
 function mdblistFolderMembers(user: AppUser, listUrl: string): CollectionMember[] {
@@ -998,10 +1001,9 @@ function sortMdblistFolderItems<T extends Record<string, unknown>>(items: T[], s
     else if (['communityrating', 'rating', 'imdbrating'].includes(normalizedSort)) result = compareNumbers(a.CommunityRating, b.CommunityRating)
     else if (['officialrating', 'parentalrating'].includes(normalizedSort)) result = compareStrings(a.OfficialRating, b.OfficialRating)
     else if (['premieredate', 'releasedate', 'productionyear'].includes(normalizedSort)) result = compareDates(a.PremiereDate ?? a.ProductionYear, b.PremiereDate ?? b.ProductionYear)
-    // MDBList rank 1 is represented by the newest synthetic DateCreated.
-    // Therefore Infuse's descending Date Added order must put source position
-    // 1 first; ascending reverses the source ranking.
-    else if (['datecreated', 'dateshowadded', 'dateadded', 'addeddate'].includes(normalizedSort)) result = sourceOrder(a, b) * -1
+    // MDBList rank 1 is represented by the oldest synthetic DateCreated, so
+    // Infuse's normal ascending Date Added order shows the ranking order.
+    else if (['datecreated', 'dateshowadded', 'dateadded', 'addeddate'].includes(normalizedSort)) result = sourceOrder(a, b)
     else if (['dateepisodeadded', 'episodeaddeddate'].includes(normalizedSort)) result = compareDates(a.EpisodeAddedDate, b.EpisodeAddedDate)
     else if (['dateplayed', 'lastplayeddate'].includes(normalizedSort)) result = compareUserData(a, b, 'LastPlayedDate')
     else if (normalizedSort === 'playcount') result = compareUserData(a, b, 'PlayCount')

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -861,13 +861,20 @@ function buildDiscoverRootFolderItem(user: AppUser) {
   }
 }
 
+function mdblistCollectionTypeForUrl(url: string): 'movies' | 'tvshows' | 'boxsets' {
+  const pathParts = mdblistListPathFromUrl(url).split('/').map(part => part.toLowerCase())
+  if (pathParts.includes('movies')) return 'movies'
+  if (pathParts.includes('shows') || pathParts.includes('series')) return 'tvshows'
+  return 'boxsets'
+}
+
 function buildMdblistCollectionItem(entry: MdblistListEntry, count: number) {
   const path = mdblistListPathFromUrl(entry.url)
   const id = mdblistCollectionIdFromPath(path)
   const name = nameForMdblistUrl(entry.url)
   return {
     Id: id, ServerId: SERVER_GUID, Name: name, SortName: name.toLowerCase(),
-    Type: 'BoxSet', CollectionType: 'boxsets', IsFolder: true,
+    Type: 'CollectionFolder', CollectionType: mdblistCollectionTypeForUrl(entry.url), IsFolder: true,
     CanDelete: false, CanDownload: false, PlayAccess: 'Full',
     ChildCount: count, RecursiveItemCount: count,
     ImageTags: { Primary: 'mdblist', Backdrop: 'mdblist' },

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -943,22 +943,84 @@ function mdblistFolderMembers(user: AppUser, listUrl: string): CollectionMember[
   })
 }
 
+function latestEpisodePlayedDate(showTmdbId: number, userId: string): string {
+  const row = getDb().prepare(`
+    SELECT max(u.last_played_date) AS last_played_date
+    FROM user_item_data u
+    JOIN episodes e
+      ON u.item_id = ('00000000-0000-4000-8003-' || lower(printf('%06x%03x%03x', e.show_tmdb_id, e.season_number, e.episode_number)))
+    WHERE u.user_id = ? AND e.show_tmdb_id = ?
+  `).get(userId, showTmdbId) as { last_played_date?: string } | undefined
+  return row?.last_played_date ?? ''
+}
+
+function latestEpisodeAddedDate(showTmdbId: number): string {
+  const row = getDb().prepare('SELECT max(synced_at) AS synced_at FROM episodes WHERE show_tmdb_id = ?')
+    .get(showTmdbId) as { synced_at?: string } | undefined
+  return row?.synced_at ?? ''
+}
+
 function sortMdblistFolderItems<T extends Record<string, unknown>>(items: T[], sortBy?: string, sortOrder?: string): T[] {
   const normalizedSort = (sortBy ?? '').split(',')[0].trim().toLowerCase()
   const normalizedOrder = (sortOrder ?? '').split(',')[0].trim().toLowerCase()
   const direction = normalizedOrder === 'ascending' || normalizedOrder === 'asc' ? 1 : -1
   const compareStrings = (a: unknown, b: unknown) => String(a ?? '').localeCompare(String(b ?? ''), undefined, { sensitivity: 'base' })
   const compareNumbers = (a: unknown, b: unknown) => (Number(a ?? 0) || 0) - (Number(b ?? 0) || 0)
+  const compareDates = (a: unknown, b: unknown) => compareStrings(a, b)
+  const compareUserData = (a: T, b: T, field: 'PlayCount' | 'LastPlayedDate') => {
+    const aValue = (a.UserData as Record<string, unknown> | undefined)?.[field]
+    const bValue = (b.UserData as Record<string, unknown> | undefined)?.[field]
+    return field === 'PlayCount' ? compareNumbers(aValue, bValue) : compareDates(aValue, bValue)
+  }
+  const sourceOrder = (a: T, b: T) => compareNumbers(a.SourcePosition, b.SourcePosition)
+    || compareStrings(a.SortName ?? a.Name, b.SortName ?? b.Name)
+
+  if (!normalizedSort) return [...items]
+  if (normalizedSort === 'random') {
+    const shuffled = [...items]
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+    }
+    return shuffled
+  }
 
   return [...items].sort((a, b) => {
-    if (['sortname', 'name'].includes(normalizedSort)) return compareStrings(a.SortName ?? a.Name, b.SortName ?? b.Name) * direction
-    if (['communityrating', 'rating', 'imdbrating'].includes(normalizedSort)) return compareNumbers(a.CommunityRating, b.CommunityRating) * direction
-    if (['officialrating', 'parentalrating'].includes(normalizedSort)) return compareStrings(a.OfficialRating, b.OfficialRating) * direction
-    if (['premieredate', 'releasedate', 'productionyear'].includes(normalizedSort)) return compareStrings(a.PremiereDate ?? a.ProductionYear, b.PremiereDate ?? b.ProductionYear) * direction
-    if (['datecreated', 'dateshowadded', 'dateadded', 'addeddate'].includes(normalizedSort)) return compareStrings(a.DateCreated, b.DateCreated) * direction
-    if (['runtime', 'runtimeticks'].includes(normalizedSort)) return compareNumbers(a.RunTimeTicks, b.RunTimeTicks) * direction
-    return compareNumbers(a.SourcePosition, b.SourcePosition) || compareStrings(a.SortName ?? a.Name, b.SortName ?? b.Name)
+    let result: number | undefined
+    if (['sortname', 'name'].includes(normalizedSort)) result = compareStrings(a.SortName ?? a.Name, b.SortName ?? b.Name)
+    else if (['communityrating', 'rating', 'imdbrating'].includes(normalizedSort)) result = compareNumbers(a.CommunityRating, b.CommunityRating)
+    else if (['officialrating', 'parentalrating'].includes(normalizedSort)) result = compareStrings(a.OfficialRating, b.OfficialRating)
+    else if (['premieredate', 'releasedate', 'productionyear'].includes(normalizedSort)) result = compareDates(a.PremiereDate ?? a.ProductionYear, b.PremiereDate ?? b.ProductionYear)
+    else if (['datecreated', 'dateshowadded', 'dateadded', 'addeddate'].includes(normalizedSort)) result = sourceOrder(a, b)
+    else if (['dateepisodeadded', 'episodeaddeddate'].includes(normalizedSort)) result = compareDates(a.EpisodeAddedDate, b.EpisodeAddedDate)
+    else if (['dateplayed', 'lastplayeddate'].includes(normalizedSort)) result = compareUserData(a, b, 'LastPlayedDate')
+    else if (normalizedSort === 'playcount') result = compareUserData(a, b, 'PlayCount')
+    else if (['runtime', 'runtimeticks'].includes(normalizedSort)) result = compareNumbers(a.RunTimeTicks, b.RunTimeTicks)
+    else if (['isfolder', 'folders'].includes(normalizedSort)) result = compareNumbers(a.IsFolder ? 1 : 0, b.IsFolder ? 1 : 0)
+    // Fetcherr does not currently store a critic score. Keep the MDBList rank
+    // stable instead of presenting TMDB's community score as a critic score.
+    else if (['criticrating', 'criticsrating'].includes(normalizedSort)) result = sourceOrder(a, b)
+    else result = sourceOrder(a, b)
+    return (result || 0) * direction
   })
+}
+
+function sortCollectionItems<T extends Record<string, unknown>>(items: T[], sortBy?: string, sortOrder?: string): T[] {
+  const normalizedSort = (sortBy ?? '').split(',')[0].trim().toLowerCase()
+  if (!normalizedSort) return [...items]
+  if (normalizedSort === 'random') {
+    const shuffled = [...items]
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+    }
+    return shuffled
+  }
+  const direction = (sortOrder ?? '').split(',')[0].trim().toLowerCase() === 'ascending' || (sortOrder ?? '').split(',')[0].trim().toLowerCase() === 'asc' ? 1 : -1
+  const compare = (a: T, b: T) => String(a.SortName ?? a.Name ?? '').localeCompare(String(b.SortName ?? b.Name ?? ''), undefined, { sensitivity: 'base' })
+  // Collection tiles have no movie/show rating, runtime, or playback value.
+  // Name is the meaningful deterministic fallback for those Infuse keys.
+  return [...items].sort((a, b) => compare(a, b) * direction)
 }
 
 async function mdblistFolderContents(listUrl: string, user: AppUser, sortBy?: string, sortOrder?: string) {
@@ -978,10 +1040,16 @@ async function mdblistFolderContents(listUrl: string, user: AppUser, sortBy?: st
     }
     const show = getShowByTmdbId(member.tmdbId) ?? await fetchShowByTmdbId(member.tmdbId)
     if (show && canUserAccessShow(user, show)) {
+      const item = showToSeriesItem(show, user.id)
       items.push({
-        ...showToSeriesItem(show, user.id),
+        ...item,
         DateCreated: dateCreatedForSourcePosition(member.syncedAt, member.sourcePosition),
+        EpisodeAddedDate: latestEpisodeAddedDate(show.tmdbId),
         SourcePosition: member.sourcePosition ?? 0,
+        UserData: {
+          ...(item.UserData as Record<string, unknown>),
+          LastPlayedDate: latestEpisodePlayedDate(show.tmdbId, user.id),
+        },
       })
     }
   }
@@ -2793,7 +2861,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
         const traktItems = traktCollectionItemsForUser(user)
         const mdblistItems = mdblistCollectionItems(user)
         const discoverItems = discoverCollectionItemsForUser(user)
-        const collections = [...traktItems, ...mdblistItems, ...discoverItems]
+        const collections = sortCollectionItems([...traktItems, ...mdblistItems, ...discoverItems], SortBy, SortOrder)
         return { Items: pagedItems(collections, offset, limit), TotalRecordCount: collections.length, StartIndex: offset }
       }
       if (includeTypes.includes('season')) {
@@ -2936,7 +3004,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const traktItems = traktCollectionItemsForUser(user)
       const mdblistItems = mdblistCollectionItems(user)
       const discoverItems = discoverCollectionItemsForUser(user)
-      const collections = [...traktItems, ...mdblistItems, ...discoverItems]
+      const collections = sortCollectionItems([...traktItems, ...mdblistItems, ...discoverItems], SortBy, SortOrder)
       return { Items: pagedItems(collections, offset, limit), TotalRecordCount: collections.length, StartIndex: offset }
     }
 
@@ -2948,7 +3016,7 @@ export async function jellyfinRoutes(app: FastifyInstance, opts: JellyfinRouteOp
       const traktItems = traktCollectionItemsForUser(user)
       const mdblistItems = mdblistCollectionItems(user)
       const discoverItems = discoverCollectionItemsForUser(user)
-      const collections = [...traktItems, ...mdblistItems, ...discoverItems]
+      const collections = sortCollectionItems([...traktItems, ...mdblistItems, ...discoverItems], SortBy, SortOrder)
       return { Items: pagedItems(collections, offset, limit), TotalRecordCount: collections.length, StartIndex: offset }
     }
 

--- a/src/jellyfin/index.ts
+++ b/src/jellyfin/index.ts
@@ -998,7 +998,10 @@ function sortMdblistFolderItems<T extends Record<string, unknown>>(items: T[], s
     else if (['communityrating', 'rating', 'imdbrating'].includes(normalizedSort)) result = compareNumbers(a.CommunityRating, b.CommunityRating)
     else if (['officialrating', 'parentalrating'].includes(normalizedSort)) result = compareStrings(a.OfficialRating, b.OfficialRating)
     else if (['premieredate', 'releasedate', 'productionyear'].includes(normalizedSort)) result = compareDates(a.PremiereDate ?? a.ProductionYear, b.PremiereDate ?? b.ProductionYear)
-    else if (['datecreated', 'dateshowadded', 'dateadded', 'addeddate'].includes(normalizedSort)) result = sourceOrder(a, b)
+    // MDBList rank 1 is represented by the newest synthetic DateCreated.
+    // Therefore Infuse's descending Date Added order must put source position
+    // 1 first; ascending reverses the source ranking.
+    else if (['datecreated', 'dateshowadded', 'dateadded', 'addeddate'].includes(normalizedSort)) result = sourceOrder(a, b) * -1
     else if (['dateepisodeadded', 'episodeaddeddate'].includes(normalizedSort)) result = compareDates(a.EpisodeAddedDate, b.EpisodeAddedDate)
     else if (['dateplayed', 'lastplayeddate'].includes(normalizedSort)) result = compareUserData(a, b, 'LastPlayedDate')
     else if (normalizedSort === 'playcount') result = compareUserData(a, b, 'PlayCount')

--- a/src/mdblist.ts
+++ b/src/mdblist.ts
@@ -9,7 +9,7 @@ import {
   upsertManualShowSubscription,
   type MediaType,
 } from './db.js'
-import { fetchMovieByTmdbId, fetchShowByTmdbId } from './tmdb.js'
+import { fetchMovieByTmdbId, fetchShowByTmdbId, findTmdbIdByImdbId } from './tmdb.js'
 
 const MDBLIST_SOURCE_PREFIX = 'mdblist:list:'
 const MDBLIST_WEB_ORIGIN = 'https://mdblist.com'
@@ -208,6 +208,40 @@ function extractPublicListEntries(html: string): MdblistEntry[] {
   return entries
 }
 
+function extractPublicListItemPaths(html: string): Array<{ mediaType: MediaType; path: string }> {
+  const entries: Array<{ mediaType: MediaType; path: string }> = []
+  const seen = new Set<string>()
+  const pattern = /class="jw-chart-card__poster"\s+href="\/(movie|show)\/([^"]+)"/gi
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(html)) !== null) {
+    const mediaType: MediaType = match[1].toLowerCase() === 'show' ? 'show' : 'movie'
+    const path = `${mediaType}/${match[2]}`
+    if (seen.has(path)) continue
+    seen.add(path)
+    entries.push({ mediaType, path })
+  }
+  return entries
+}
+
+async function extractCurrentPublicListEntries(html: string, maxEntries: number): Promise<MdblistEntry[]> {
+  const directEntries = extractPublicListEntries(html)
+  if (directEntries.length) return directEntries.slice(0, maxEntries)
+
+  const itemPaths = extractPublicListItemPaths(html).slice(0, maxEntries)
+  const resolved = await Promise.all(itemPaths.map(async ({ mediaType, path }, index) => {
+    try {
+      const detailHtml = await fetchPublicListHtml(`${MDBLIST_WEB_ORIGIN}/${path}`)
+      const imdbMatch = detailHtml.match(/imdb\.com\/title\/(tt\d+)/i)
+      if (!imdbMatch) return null
+      const tmdbId = await findTmdbIdByImdbId(imdbMatch[1], mediaType)
+      return tmdbId ? { tmdbId, mediaType, rank: index + 1 } : null
+    } catch {
+      return null
+    }
+  }))
+  return resolved.filter((entry): entry is NonNullable<typeof entry> => !!entry)
+}
+
 interface MdblistApiItem {
   id?: number
   rank?: number
@@ -341,7 +375,7 @@ async function fetchMdblistEntries(listUrl: string, maxEntries: number): Promise
     return result
   }
   const html = await fetchPublicListHtml(listUrl)
-  const allEntries = extractPublicListEntries(html)
+  const allEntries = await extractCurrentPublicListEntries(html, maxEntries)
   if (!allEntries.length) {
     throw new Error('No TMDB links found on public MDBList page')
   }

--- a/src/playback-profiles.ts
+++ b/src/playback-profiles.ts
@@ -1,0 +1,23 @@
+// These are lightweight list markers. Infuse uses them to discover that an
+// item has multiple playable sources, then requests the item detail where the
+// real Stremio-backed versions are returned.
+export type PlaybackProfileKey =
+  | 'probe-a'
+  | 'probe-b'
+
+export type PlaybackProfile = {
+  key: PlaybackProfileKey
+  name: string
+  targetHeight?: number
+  targetBitrateMbps?: number
+}
+
+export const PLAYBACK_PROFILES: readonly PlaybackProfile[] = [
+  { key: 'probe-a', name: 'Fetcherr Version Discovery A' },
+  { key: 'probe-b', name: 'Fetcherr Version Discovery B' },
+]
+
+export function playbackProfileForKey(value: string | undefined): PlaybackProfile | null {
+  if (!value) return null
+  return PLAYBACK_PROFILES.find(profile => profile.key === value) ?? null
+}

--- a/src/sootio.ts
+++ b/src/sootio.ts
@@ -108,6 +108,11 @@ interface RankedStreamScore {
 
 const PROVIDER_METRICS_MAX = 250
 const providerFetchMetrics: ProviderFetchMetric[] = []
+const STREAM_RESPONSE_CACHE_TTL_MS = 60 * 1000
+const STREAM_RESPONSE_CACHE_MAX_ITEMS = 200
+type StreamResponseCacheEntry = { streams: Stream[]; expiresAt: number }
+const streamResponseCache = new Map<string, StreamResponseCacheEntry>()
+const streamResponseInFlight = new Map<string, Promise<Stream[]>>()
 
 function recordProviderFetchMetric(metric: ProviderFetchMetric): void {
   providerFetchMetrics.push(metric)
@@ -609,7 +614,15 @@ export function summarizeStreamForLog(s: Stream): string {
   ].join(' ')
 }
 
-async function fetchStreamsFromProviders(path: string): Promise<Stream[]> {
+function trimStreamResponseCache(): void {
+  while (streamResponseCache.size > STREAM_RESPONSE_CACHE_MAX_ITEMS) {
+    const firstKey = streamResponseCache.keys().next().value as string | undefined
+    if (firstKey === undefined) break
+    streamResponseCache.delete(firstKey)
+  }
+}
+
+async function fetchStreamsFromProvidersUncached(path: string): Promise<Stream[]> {
   const providers = providerBases()
   if (!providers.length) throw new Error('No stream provider URL configured')
 
@@ -685,6 +698,34 @@ async function fetchStreamsFromProviders(path: string): Promise<Stream[]> {
   }
 
   return [...deduped.values()]
+}
+
+async function fetchStreamsFromProviders(path: string): Promise<Stream[]> {
+  const now = Date.now()
+  const cached = streamResponseCache.get(path)
+  if (cached && cached.expiresAt > now) {
+    console.log(`streams: cache hit for ${path} (${cached.streams.length} streams)`)
+    return cached.streams
+  }
+  if (cached) streamResponseCache.delete(path)
+
+  const existing = streamResponseInFlight.get(path)
+  if (existing) {
+    console.log(`streams: reusing in-flight request for ${path}`)
+    return existing
+  }
+
+  const request = fetchStreamsFromProvidersUncached(path)
+    .then(streams => {
+      streamResponseCache.set(path, { streams, expiresAt: Date.now() + STREAM_RESPONSE_CACHE_TTL_MS })
+      trimStreamResponseCache()
+      return streams
+    })
+    .finally(() => {
+      if (streamResponseInFlight.get(path) === request) streamResponseInFlight.delete(path)
+    })
+  streamResponseInFlight.set(path, request)
+  return request
 }
 
 /**

--- a/src/tmdb.ts
+++ b/src/tmdb.ts
@@ -31,6 +31,15 @@ async function tmdbGet(path: string): Promise<unknown> {
   return res.json()
 }
 
+export async function findTmdbIdByImdbId(imdbId: string, mediaType: 'movie' | 'show'): Promise<number | null> {
+  const result = await tmdbGet(`/find/${encodeURIComponent(imdbId)}?external_source=imdb_id`) as {
+    movie_results?: Array<{ id: number }>
+    tv_results?: Array<{ id: number }>
+  }
+  const match = (mediaType === 'movie' ? result.movie_results : result.tv_results)?.[0]
+  return match?.id && Number.isFinite(match.id) ? match.id : null
+}
+
 function shouldRetryMissingStillBackfill(episodes: Episode[]): boolean {
   const now = Date.now()
   return episodes.some(ep => {


### PR DESCRIPTION
## Summary

- Rename the misleading mock Jellyfin client into an explicit client-side integration probe.
- Make playback validation work with either direct media responses or HTTP redirects from Jellyfin-compatible endpoints.
- Allow targeted validation of a selected season and episode instead of silently probing the first episode found.

## Relationship to PR #29

This branch is based on the local `main`, which includes the changes proposed in [PR #29](https://github.com/goneturbo/fetcherr/pull/29). Please merge #29 first; after that, the net change in this PR is Feature 1 only. The probe does not add deletion or the experimental Infuse Sync trigger.

## Scope

This is intended for automated agent and CI testing of Fetcherr or a real Jellyfin-compatible service. It does not add a mock Jellyfin server or change production playback behavior.

## Validation

- `npm run probe:jellyfin -- --help`
- `npm run build`
- `docker build -t fetcherr:test .`
