### PR TITLE
docs: explain Trakt's one-app connection limit, point to MDBList

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Configure AIOStreams with your provider, then paste the manifest URL into Fetche
 
 Fetcherr also has mediated support for direct playable URLs returned by AIOStreams. For example, if your AIOStreams instance is configured with EasyNews and returns an EasyNews-backed stream URL, Fetcherr can unwrap and play that URL through the normal playback resolver. When AIOStreams returns mixed direct URL, TorBox, and Real-Debrid candidates, Fetcherr can try the direct URL first, then fall back to TorBox or Real-Debrid.
 
+### Trakt connection limits
+
+Trakt now limits free accounts to one connected third-party app at a time — connecting a second app (Kometa, a scrobbler, Fetcherr, etc.) revokes whichever app was connected first. This is a Trakt account policy, not a Fetcherr bug or bitrate/traffic issue; Fetcherr detects the resulting token revocation and prompts you to reconnect in **Settings**, but it can't avoid consuming a connection slot.
+
+If you already use another Trakt-connected app and don't want Fetcherr to compete for that one free slot, use **MDBList** as your sync source instead — Fetcherr supports MDBList lists and watchlists with no Trakt connection required.
+
 ## Search Results
 
 Fetcherr exposes Jellyfin-compatible search results from both the synced library and configured Stremio add-ons. This lets clients find playable movies and shows returned by providers such as AIOStreams, then open them through the same Fetcherr playback resolver used by library items.

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -1362,7 +1362,7 @@
       const callout = document.getElementById('traktCallout')
       callout.className = 'callout error'
       callout.style.display = ''
-      callout.textContent = d.authError.message
+      callout.textContent = `${d.authError.message} Prefer to keep your other Trakt app connected instead? Switch to MDBList as your sync source — it needs no Trakt connection.`
       return
     }
     if (d.authenticated) {


### PR DESCRIPTION
## Why

Trakt now limits free accounts to one connected third-party app at a time — connecting a second app revokes whichever was connected first. Fetcherr already detects this (commit `78a8f53`, "detect Trakt token revocation and surface reconnect alert") and prompts reconnect in Settings, but there was no documentation explaining *why* this happens, and no path offered to users who'd rather keep another Trakt-connected app and not have Fetcherr compete for their one free slot.

## What

- **README**: new "Trakt connection limits" subsection explaining the policy and pointing at MDBList as a zero-Trakt-connection sync alternative.
- **`settings.html`**: the existing reconnect-needed callout now also suggests switching to MDBList, right at the moment a user hits the limit. The underlying error message/logging in `trakt.ts` is unchanged.

Docs/UI copy only — no behavior change, no new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
