### PR TITLE
Coalesce provider stream fetches and stop caching empty results as failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,7 @@ function requestPlaybackUser(headers: Record<string, string | string[] | undefin
 function pad2(n: number) { return n.toString().padStart(2, '0') }
 
 const FAILED_PLAY_TTL_MS = 3 * 60 * 1000
+const FAILED_PLAY_EMPTY_TTL_MS = 15_000
 const PLAYBACK_PREWARM_TTL_MS = 5 * 60 * 1000
 const MAX_RD_TRANSIENT_FAILURES = 3
 type FailedPlayCacheEntry = { expiresAt: number; reason: string }
@@ -236,11 +237,22 @@ function getFailedPlayReason(cacheKey: string): string | null {
   return entry.reason
 }
 
-function cacheFailedPlay(cacheKey: string, reason: string) {
+function cacheFailedPlay(cacheKey: string, reason: string, ttlMs = FAILED_PLAY_TTL_MS) {
   failedPlayCache.set(cacheKey, {
-    expiresAt: Date.now() + FAILED_PLAY_TTL_MS,
+    expiresAt: Date.now() + ttlMs,
     reason,
   })
+}
+
+// Empty provider results (e.g. AIOStreams answering mid-scrape while a season
+// view bursts a dozen parallel fetches) are transient: cache the miss only
+// briefly so a retry succeeds within seconds. Genuine resolver failures keep
+// the longer TTL.
+function failedPlayTtlMs(err: unknown): number {
+  const message = err instanceof Error ? err.message : String(err)
+  return /\bNo (?:ranked |year-matched )?streams found\b/.test(message)
+    ? FAILED_PLAY_EMPTY_TTL_MS
+    : FAILED_PLAY_TTL_MS
 }
 
 function clearFailedPlay(cacheKey: string) {
@@ -1814,7 +1826,7 @@ app.get('/play/stremio/:mediaType/:externalId', async (req, reply) => {
       return reply.code(err.statusCode).send(err.response)
     }
     app.log.warn(`play: no Stremio stream for ${mediaType} ${decodedExternalId}: ${err}`)
-    cacheFailedPlay(playPath, 'No streams found')
+    cacheFailedPlay(playPath, 'No streams found', failedPlayTtlMs(err))
     return reply.code(404).send({ error: 'No stream available', message: 'No Streams Found' })
   }
 })
@@ -1852,7 +1864,7 @@ app.get('/play/:imdbId', async (req, reply) => {
       return reply.code(err.statusCode).send(err.response)
     }
     app.log.warn(`play: no stream for ${imdbId}: ${err}`)
-    cacheFailedPlay(playPath, 'No streams found')
+    cacheFailedPlay(playPath, 'No streams found', failedPlayTtlMs(err))
     return reply.code(404).send({ error: 'No stream available', message: 'No Streams Found' })
   }
 })
@@ -1893,7 +1905,7 @@ app.get('/play/:imdbId/:season/:episode', async (req, reply) => {
       return reply.code(err.statusCode).send(err.response)
     }
     app.log.warn(`play: no stream for ${imdbId} S${s}E${e}: ${err}`)
-    cacheFailedPlay(playPath, 'No streams found')
+    cacheFailedPlay(playPath, 'No streams found', failedPlayTtlMs(err))
     return reply.code(404).send({ error: 'No stream available', message: 'No Streams Found' })
   }
 })

--- a/src/sootio.ts
+++ b/src/sootio.ts
@@ -609,7 +609,51 @@ export function summarizeStreamForLog(s: Stream): string {
   ].join(' ')
 }
 
+const STREAM_RESULT_CACHE_TTL_MS = 90_000
+type StreamFetchCacheEntry = { promise: Promise<Stream[]>; expiresAt: number }
+const streamFetchCache = new Map<string, StreamFetchCacheEntry>()
+
+function cleanupStreamFetchCache(now: number) {
+  for (const [key, entry] of streamFetchCache) {
+    if (entry.expiresAt <= now) streamFetchCache.delete(key)
+  }
+}
+
+/**
+ * Coalesce concurrent provider fetches for the same path (e.g. Infuse
+ * requesting MediaSources for a whole season at once) into a single query,
+ * and reuse successful results briefly. Empty or failed fetches are never
+ * cached, so the next caller queries the providers again.
+ */
 async function fetchStreamsFromProviders(path: string): Promise<Stream[]> {
+  const now = Date.now()
+  cleanupStreamFetchCache(now)
+  const existing = streamFetchCache.get(path)
+  if (existing) {
+    console.log(`streams: reusing in-flight or cached provider fetch for ${path}`)
+    return existing.promise
+  }
+
+  const promise = fetchStreamsFromProvidersUncached(path).then(
+    streams => {
+      const current = streamFetchCache.get(path)
+      if (current?.promise === promise) {
+        if (streams.length) current.expiresAt = Date.now() + STREAM_RESULT_CACHE_TTL_MS
+        else streamFetchCache.delete(path)
+      }
+      return streams
+    },
+    err => {
+      const current = streamFetchCache.get(path)
+      if (current?.promise === promise) streamFetchCache.delete(path)
+      throw err
+    },
+  )
+  streamFetchCache.set(path, { promise, expiresAt: now + STREAM_RESULT_CACHE_TTL_MS })
+  return promise
+}
+
+async function fetchStreamsFromProvidersUncached(path: string): Promise<Stream[]> {
   const providers = providerBases()
   if (!providers.length) throw new Error('No stream provider URL configured')
 


### PR DESCRIPTION
Infuse season views request stream options for every visible episode at once. Each request triggered its own provider fetch, and under that burst the addon (AIOStreams in our case, mid-scrape) returns empty results for most of them. Those empties then landed in failedPlayCache for 3 minutes, and every retry inside the window re-armed it, so titles looked permanently broken while a solo query for the same episode returned 8 streams in 800ms.

Two changes:

- fetchStreamsFromProviders now coalesces concurrent identical requests into one shared in-flight promise, and caches non-empty successful results for 90 seconds. Empty or thrown results are never cached, so the next caller re-fetches. A 12-episode season view now costs one provider query per episode instead of one per client request.
- failedPlayCache distinguishes empty-results failures (15 second TTL) from genuine resolver errors (unchanged 3 minutes). A play pressed right after a burst recovers in seconds instead of minutes.

Notes for review: the failure classification matches the error wording at the throw sites in sootio.ts and falls back to the old 3-minute behavior if a message is reworded; a comment marks the coupling. The 90 second success cache means a freshly added debrid file can take up to 90 seconds to appear in media source lists, which felt like the right trade against re-scraping on every request.

Tested on our instance (TorBox + AIOStreams): 8 parallel fetches of one episode produced exactly one provider query with all 8 callers served, and a real episode resolved in under a second right after a nonexistent one was requested. Build is green with tsc on node 20.
