### PR TITLE
Drop zero-progress watch-state rows from failed plays

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2260,10 +2260,10 @@ export function getUserData(itemId: string, userId = DEFAULT_ADMIN_USER_ID): Use
 }
 
 export function clearProgress(itemId: string, userId = DEFAULT_ADMIN_USER_ID): void {
+  // Update-only on purpose: a missing row already means "no progress", and
+  // failed play attempts report position 0, which used to insert junk rows here.
   getDb().prepare(`
-    INSERT INTO user_item_data (user_id, item_id, position_ticks)
-    VALUES (?, ?, 0)
-    ON CONFLICT(user_id, item_id) DO UPDATE SET position_ticks = 0
+    UPDATE user_item_data SET position_ticks = 0 WHERE user_id = ? AND item_id = ?
   `).run(userId, itemId)
 }
 
@@ -2389,15 +2389,16 @@ export function syncPlayed(itemId: string, lastPlayedDate: string, userId = DEFA
 
 export function markUnplayed(itemId: string, userId = DEFAULT_ADMIN_USER_ID): void {
   const now = new Date().toISOString()
+  // Update-only on purpose: unplaying an item that has no row is a no-op, and
+  // clients that bulk-sync watched state would otherwise insert junk rows.
   getDb().prepare(`
-    INSERT INTO user_item_data (user_id, item_id, played, play_count, position_ticks, last_played_date, watch_state_source, watch_state_updated_at)
-    VALUES (?, ?, 0, 0, 0, '', 'local', ?)
-    ON CONFLICT(user_id, item_id) DO UPDATE SET
+    UPDATE user_item_data SET
       played                 = 0,
       play_count             = 0,
       position_ticks         = 0,
       last_played_date       = '',
       watch_state_source     = 'local',
-      watch_state_updated_at = excluded.watch_state_updated_at
-  `).run(userId, itemId, now)
+      watch_state_updated_at = ?
+    WHERE user_id = ? AND item_id = ?
+  `).run(now, userId, itemId)
 }


### PR DESCRIPTION
Failed play attempts were persisting zero-progress rows in user_item_data: a Progress or Stopped report at position 0 for a never-seen item created a row carrying no information, and markUnplayed on a never-seen item did the same. These rows accumulate indefinitely, one per failed attempt per item, and nothing cleans them up.

The fix makes zero-information reports UPDATE-only: they can modify an existing row but no longer create one. Real progress, resume, markPlayed, and markUnplayed on existing rows behave exactly as before (verified before and after on a scratch instance: the repro that used to create 4 junk rows now creates none, with all legitimate round-trips intact).

Scope correction from our own review, for accuracy: an earlier version of this description attributed the Infuse "file not found" Up Next tiles to these rows. That was wrong. Zero-progress rows fail both resume and played read predicates and are never served to clients; the tile symptom comes from real-progress rows on search items and is addressed in #35. This PR is database hygiene: it stops the junk rows at the source.

One corner case worth stating: markUnplayed on an item with no row previously wrote a tombstone that shielded against an older Trakt sync re-marking it played. That shield is gone for never-seen items. The window is transient (the next sync converges) and the post-fix behavior seemed defensible, but happy to add the tombstone back behind a played=0 row with a flag if you prefer.

Build green with tsc on node 20.
