### PR TITLE
feat: surface source language in media source picker labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetcherr",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetcherr",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "dependencies": {
         "@viren070/parse-torrent-title": "^0.7.6",
         "better-sqlite3": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcherr",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Jellyfin-compatible bridge for Infuse with Trakt library sync and Real-Debrid, TorBox, or Premiumize stream resolution.",
   "type": "module",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1189,6 +1189,7 @@ function streamOptionName(stream: Stream, fallbackName: string, index: number): 
     compactHdrLabel(parsed, text),
     compactFeatureLabel(parsed, text),
     compactAudioLabel(parsed, text),
+    compactLanguageLabel(parsed),
     compactSizeLabel(stream, parsed),
     compactProviderLabel(stream, index),
   ])
@@ -1331,6 +1332,19 @@ function compactAudioLabel(parsed: ParsedTorrentTitleResult, text: string): stri
   if (/\bflac\b/i.test(combined)) return 'FLAC'
   if (/\baac\b/i.test(combined)) return 'AAC'
   return undefined
+}
+
+// Omits English (the default assumption for most of the catalog) so the
+// common case stays quiet — only surfaces when a source is dubbed/foreign or
+// carries multiple audio tracks, which is the actual disambiguation need
+// (issue #26).
+function compactLanguageLabel(parsed: ParsedTorrentTitleResult): string | undefined {
+  const languages = (parsed.languages ?? []).map(lang => lang.toLowerCase())
+  if (languages.some(lang => lang.includes('multi'))) return 'Multi'
+  if (languages.some(lang => lang.includes('dual'))) return 'Dual'
+  const code = languages.find(lang => lang in LANGUAGE_ISO3 && lang !== 'en')
+  if (!code) return undefined
+  return code === 'zh-tw' ? 'ZH' : code.toUpperCase()
 }
 
 function compactSizeLabel(stream: Stream, parsed?: ParsedTorrentTitleResult): string | undefined {


### PR DESCRIPTION
Partial fix for #26.

Media source Name labels already synthesize resolution, source, codec, HDR, feature, audio-format, size, and provider tags from the same parse-torrent-title pass, but dropped language entirely. Adds a language token: stays quiet for the default English case, surfaces `Multi`/`Dual` for multi-track releases or the actual language code for dubbed/foreign sources.

Indexer is already covered (the provider tag at the end of the label). Filename is a bigger question (no spare field to put it in without either crowding out the compact tags or adding an opt-in verbose-naming toggle) and is intentionally left open pending more input from the reporter.

Version bumped to 1.8.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)